### PR TITLE
Google play services check minimum version

### DIFF
--- a/app/src/main/java/fi/thl/koronahaavi/common/ENEnablerFragment.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/common/ENEnablerFragment.kt
@@ -90,7 +90,7 @@ open class ENEnablerFragment : Fragment() {
      */
     protected fun startEnablingSystem() {
         val gaa = GoogleApiAvailability.getInstance()
-        val result = gaa.isGooglePlayServicesAvailable(activity)
+        val result = gaa.isGooglePlayServicesAvailable(requireContext(), MIN_GOOGLE_PLAY_VERSION)
 
         if (result == ConnectionResult.SUCCESS) {
             Timber.v("Play services up-to-date")
@@ -120,6 +120,10 @@ open class ENEnablerFragment : Fragment() {
                 // -> play dialog result is posted to playServicesResolvedEvent
             }
         }
+    }
+
+    companion object {
+        const val MIN_GOOGLE_PLAY_VERSION = 201813000   // v20.18.13
     }
 }
 


### PR DESCRIPTION
When checking for Google Play Services availability during onboarding, this change specifies the minimum required version in order to use Exposure notifications.

Without this change the need to update Google Play Services is only detected if play services version is very old (factory version) but not when it's only slightly old.