### PR TITLE
CI: Also test pull requests

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -3,6 +3,8 @@ name: Check dependencies
 on:
   push:
     branches: '*'
+  pull_request:
+    branches: '*'
   schedule:
   - cron:  "0 5 * * *" # this is utc time
 

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: '*'
   pull_request:
-    branches: '*'
+    branches: 'trunk'
   schedule:
   - cron:  "0 5 * * *" # this is utc time
 


### PR DESCRIPTION
Currently, GitHub Actions only runs for pushes and cron runs.

That means PRs from third-parties aren't tested. For example: https://github.com/THLfi/koronavilkku-android/pull/12.

This enables tests on PRs.