### PR TITLE
Prevent errors from invalid format in persisted municipality fie

### DIFF
--- a/app/src/main/java/fi/thl/koronahaavi/exposure/Municipality.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/exposure/Municipality.kt
@@ -1,17 +1,12 @@
 package fi.thl.koronahaavi.exposure
 
-import fi.thl.koronahaavi.data.ServiceLanguages
+import fi.thl.koronahaavi.data.OmaoloFeatures
 
 data class Municipality (
     val code: String,
     val name: String,
     val omaoloFeatures: OmaoloFeatures,
     val contacts: List<MunicipalityContact>
-)
-
-data class OmaoloFeatures(
-    val available: Boolean,
-    val serviceLanguages: ServiceLanguages
 )
 
 data class MunicipalityContact (

--- a/app/src/test/resources/municipalities_invalid.json
+++ b/app/src/test/resources/municipalities_invalid.json
@@ -1,0 +1,93 @@
+[
+  {
+    "code": "837",
+    "name": {
+      "fi": "Tampere",
+      "sv": "Tammerfors",
+      "en": "Tampere"
+    },
+    "omaolo": {
+      "available": false
+    },
+    "contact": [
+      {
+        "title": {
+          "fi": "Tays Keskussairaala",
+          "sv": "Tammerfors universitetssjukhus",
+          "en": "Central Hospital in Tampere"
+        },
+        "info": {
+          "fi": "Maanantai-sunnuntai 7-17",
+          "sv": "Måndag-söndag 7-17",
+          "en": "Monday to Sunday 7am - 7pm"
+        }
+      },
+      {
+        "title": {
+          "fi": "Tays Hatanpää",
+          "sv": "Tays Hatanpää sjukhus",
+          "en": "Tays Hatanpää Hospital"
+        },
+        "info": {
+          "fi": "Maanantai-perjantai 8-15",
+          "sv": "Måndag-fredag 8-15",
+          "en": "Monday to Friday 8am - 3pm"
+        }
+      }
+    ]
+  },
+  {
+    "code": "091",
+    "name": {
+      "fi": "Helsinki",
+      "sv": "Helsingfors",
+      "en": "Helsinki"
+    },
+    "omaolo": {
+      "available": true,
+      "serviceLanguages": {
+        "fi": true,
+        "sv": false,
+        "en": false
+      }
+    },
+    "contact": [
+      {
+        "title": {
+          "fi": "Meilahden sairaala",
+          "sv": "Mejlans sjukhus",
+          "en": "Meilahti Hospital"
+        },
+        "info": {
+          "fi": "Maanantai-sunnuntai 6-18",
+          "sv": "Måndag-söndag 6-18",
+          "en": "Monday to Sunday 6am - 6pm"
+        }
+      },
+      {
+        "title": {
+          "fi": "Laakson sairaala",
+          "sv": "Dals sjukhus",
+          "en": "Laakso Hospital"
+        },
+        "info": {
+          "fi": "Maanantai-perjantai 7-16",
+          "sv": "Måndag - fredag 7-16",
+          "en": "Monday to Friday 7am - 4pm"
+        }
+      },
+      {
+        "title": {
+          "fi": "Herttoniemen sairaala",
+          "sv": "Hertonäs sjukhus",
+          "en": "Herttoniemi Hospital"
+        },
+        "info": {
+          "fi": "Maanantai-perjantai 8-18",
+          "sv": "Måndag - fredag 8-18",
+          "en": "Monday to Friday 8am - 6pm"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Catch also possible json deserialization errors when reading persisted municipality file. 
Also add missing JsonClass annotations to get generated adapter classes.