### PR TITLE
Improve error messages when exposure notifications start fails

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-base:$playVersion"
     implementation "com.google.android.gms:play-services-basement:$playVersion"
     implementation 'com.google.android.gms:play-services-safetynet:17.0.0'
-    implementation 'com.google.android.gms:play-services-tasks:17.1.0'
+    implementation 'com.google.android.gms:play-services-tasks:17.2.0'
 
     // Security
     implementation 'androidx.security:security-crypto:1.0.0-rc02'  // 1.0 on purpose until 1.1 past alpha

--- a/app/src/main/java/fi/thl/koronahaavi/common/ENEnablerFragment.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/common/ENEnablerFragment.kt
@@ -143,7 +143,7 @@ fun Context.showEnableFailureReasonDialog(error: EnableENError) {
                 when (it) {
                     is ENApiError.DeviceNotSupported -> getString(R.string.enable_err_api_connection_device)
                     is ENApiError.AppNotAuthorized -> getString(R.string.enable_err_api_connection_unauthorized)
-                    is ENApiError.Failed -> getString(R.string.enable_err_api_connection_generic, it.errorCode ?: 0)
+                    is ENApiError.Failed -> getString(R.string.enable_err_api_connection_generic, it.errorCode)
                 }
             }
 
@@ -155,7 +155,7 @@ fun Context.showEnableFailureReasonDialog(error: EnableENError) {
         is EnableENError.Failed -> {
             builder.setMessage(
                 error.code?.let {
-                    getString(R.string.enable_error_api_code, it, error.connectionErrorCode ?: 0)
+                    getString(R.string.enable_error_api_code, it, error.connectionErrorCode)
                 } ?:
                 getString(R.string.enable_err_generic)
             )

--- a/app/src/main/java/fi/thl/koronahaavi/common/ENEnablerFragment.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/common/ENEnablerFragment.kt
@@ -136,10 +136,16 @@ fun Context.showEnableFailureReasonDialog(error: EnableENError) {
         is EnableENError.MissingCapability -> {
             builder.setMessage(R.string.enable_err_missing_capability)
         }
+        is EnableENError.ApiNotSupported -> {
+            builder.setMessage(
+                getString(R.string.enable_err_api_not_supported, error.connectionErrorCode ?: 0
+            ))
+        }
+
         is EnableENError.Failed -> {
             builder.setMessage(
                 error.code?.let {
-                    getString(R.string.enable_error_api_code, it)
+                    getString(R.string.enable_error_api_code, it, error.connectionErrorCode ?: 0)
                 } ?:
                 getString(R.string.enable_err_generic)
             )

--- a/app/src/main/java/fi/thl/koronahaavi/common/ENEnablerFragment.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/common/ENEnablerFragment.kt
@@ -15,6 +15,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import fi.thl.koronahaavi.R
 import fi.thl.koronahaavi.common.RequestResolutionViewModel.Companion.REQUEST_CODE_PLAY_SERVICES_ERROR_DIALOG
+import fi.thl.koronahaavi.settings.ENApiError
 import fi.thl.koronahaavi.settings.EnableENError
 import fi.thl.koronahaavi.settings.EnableSystemViewModel
 import kotlinx.coroutines.launch
@@ -136,10 +137,19 @@ fun Context.showEnableFailureReasonDialog(error: EnableENError) {
         is EnableENError.MissingCapability -> {
             builder.setMessage(R.string.enable_err_missing_capability)
         }
+
         is EnableENError.ApiNotSupported -> {
+            val apiError = error.enApiError?.let {
+                when (it) {
+                    is ENApiError.DeviceNotSupported -> getString(R.string.enable_err_api_connection_device)
+                    is ENApiError.AppNotAuthorized -> getString(R.string.enable_err_api_connection_unauthorized)
+                    is ENApiError.Failed -> getString(R.string.enable_err_api_connection_generic, it.errorCode ?: 0)
+                }
+            }
+
             builder.setMessage(
-                getString(R.string.enable_err_api_not_supported, error.connectionErrorCode ?: 0
-            ))
+                getString(R.string.enable_err_api_not_supported, apiError)
+            )
         }
 
         is EnableENError.Failed -> {

--- a/app/src/main/java/fi/thl/koronahaavi/home/HomeViewModel.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import fi.thl.koronahaavi.device.SystemStateLiveData
 import fi.thl.koronahaavi.service.ExposureNotificationService
 import fi.thl.koronahaavi.service.ExposureNotificationService.ResolvableResult
 import fi.thl.koronahaavi.settings.EnableENError
+import fi.thl.koronahaavi.settings.toENApiError
 import kotlinx.coroutines.launch
 
 class HomeViewModel @ViewModelInject constructor(
@@ -58,12 +59,17 @@ class HomeViewModel @ViewModelInject constructor(
                 }
                 is ResolvableResult.Failed -> {
                     enableENErrorEvent.postValue(Event(
-                        EnableENError.Failed(code = result.apiErrorCode)
+                        EnableENError.Failed(code = result.apiErrorCode, connectionErrorCode = result.connectionErrorCode)
                     ))
                 }
                 is ResolvableResult.MissingCapability -> {
                     enableENErrorEvent.postValue(Event(
                         EnableENError.MissingCapability
+                    ))
+                }
+                is ResolvableResult.ApiNotSupported -> {
+                    enableENErrorEvent.postValue(Event(
+                        EnableENError.ApiNotSupported(result.connectionError?.toENApiError())
                     ))
                 }
             }

--- a/app/src/main/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorker.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorker.kt
@@ -104,7 +104,7 @@ class DiagnosisKeyUpdateWorker @WorkerInject constructor(
                 false
             }
             is ResolvableResult.ApiNotSupported -> {
-                Timber.e("provideDiagnosisKeys call failed with api not supported, error: %s", result.error)
+                Timber.e("provideDiagnosisKeys call failed with api not supported")
                 false
             }
             is ResolvableResult.ResolutionRequired -> {

--- a/app/src/main/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorker.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorker.kt
@@ -103,6 +103,10 @@ class DiagnosisKeyUpdateWorker @WorkerInject constructor(
                 Timber.e("provideDiagnosisKeys call failed with missing capability, error: %s", result.error)
                 false
             }
+            is ResolvableResult.ApiNotSupported -> {
+                Timber.e("provideDiagnosisKeys call failed with api not supported, error: %s", result.error)
+                false
+            }
             is ResolvableResult.ResolutionRequired -> {
                 // this should not occur from provideDiagnosisKeys API call but handling it anyway
                 Timber.e("provideDiagnosisKeys call failed requiring resolution, status code: %d", result.status.statusCode)

--- a/app/src/main/java/fi/thl/koronahaavi/service/ExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/ExposureNotificationService.kt
@@ -31,8 +31,16 @@ interface ExposureNotificationService {
         data class ResolutionRequired<T>(val status: Status) : ResolvableResult<T>()
         data class Success<T>(val data: T) : ResolvableResult<T>()
         data class MissingCapability<T>(val error: String?) : ResolvableResult<T>()
-        data class ApiNotSupported<T>(val connectionErrorCode: Int?, val error: String?) : ResolvableResult<T>()
+        data class ApiNotSupported<T>(val connectionError: ConnectionError?) : ResolvableResult<T>()
         data class Failed<T>(val apiErrorCode: Int? = null, val connectionErrorCode: Int? = null, val error: String?) : ResolvableResult<T>()
+    }
+
+    // These map to ExposureNotificationStatusCodes, but only the ones have been defined which
+    // we need to handle in user interface to show specific error
+    sealed class ConnectionError {
+        object DeviceNotSupported: ConnectionError()  // 39501
+        object ClientNotAuthorized: ConnectionError()  // 39507
+        data class Failed(val errorCode: Int?): ConnectionError()
     }
 }
 

--- a/app/src/main/java/fi/thl/koronahaavi/service/ExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/ExposureNotificationService.kt
@@ -31,7 +31,8 @@ interface ExposureNotificationService {
         data class ResolutionRequired<T>(val status: Status) : ResolvableResult<T>()
         data class Success<T>(val data: T) : ResolvableResult<T>()
         data class MissingCapability<T>(val error: String?) : ResolvableResult<T>()
-        data class Failed<T>(val apiErrorCode: Int? = null, val error: String?) : ResolvableResult<T>()
+        data class ApiNotSupported<T>(val connectionErrorCode: Int?, val error: String?) : ResolvableResult<T>()
+        data class Failed<T>(val apiErrorCode: Int? = null, val connectionErrorCode: Int? = null, val error: String?) : ResolvableResult<T>()
     }
 }
 

--- a/app/src/main/java/fi/thl/koronahaavi/service/GoogleExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/GoogleExposureNotificationService.kt
@@ -85,6 +85,8 @@ class GoogleExposureNotificationService(
                 return ResolvableResult.ResolutionRequired(exception.status)
             }
 
+            Timber.e(exception, "Exposure notification API call failed")
+
             if (exception.statusCode == ExposureNotificationStatusCodes.FAILED_NOT_SUPPORTED) {
                 return ResolvableResult.MissingCapability(exception.localizedMessage)
             }
@@ -98,7 +100,6 @@ class GoogleExposureNotificationService(
                 )
             }
 
-            Timber.e(exception, "Exposure notification API call failed")
             return ResolvableResult.Failed(
                 apiErrorCode = exception.statusCode,
                 connectionErrorCode = exception.status.connectionResult?.errorCode,

--- a/app/src/main/java/fi/thl/koronahaavi/settings/EnableSystemViewModel.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/settings/EnableSystemViewModel.kt
@@ -48,13 +48,22 @@ class EnableSystemViewModel @ViewModelInject constructor(
             }
             is ResolvableResult.Failed -> {
                 enableENErrorEvent.postValue(Event(
-                    EnableENError.Failed(code = result.apiErrorCode)
+                    EnableENError.Failed(
+                        code = result.apiErrorCode,
+                        connectionErrorCode = result.connectionErrorCode
+                    )
                 ))
                 false
             }
             is ResolvableResult.MissingCapability -> {
                 enableENErrorEvent.postValue(Event(
                     EnableENError.MissingCapability
+                ))
+                false
+            }
+            is ResolvableResult.ApiNotSupported -> {
+                enableENErrorEvent.postValue(Event(
+                    EnableENError.ApiNotSupported(result.connectionErrorCode)
                 ))
                 false
             }
@@ -68,5 +77,6 @@ class EnableSystemViewModel @ViewModelInject constructor(
 
 sealed class EnableENError {
     object MissingCapability : EnableENError()
-    data class Failed(val code: Int? = null, val error: String? = null): EnableENError()
+    data class ApiNotSupported(val connectionErrorCode: Int? = null): EnableENError()
+    data class Failed(val code: Int? = null, val connectionErrorCode: Int? = null, val error: String? = null): EnableENError()
 }

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -155,9 +155,10 @@
 
     <string name="enable_err_title">Exponeringsloggen kunde inte startas</string>
     <string name="enable_err_missing_capability">Din enhet stöds ej</string>
+    <string name="enable_err_api_not_supported">Din enhet stöder inte exponeringsmeddelanden. För att kontrollera versionen av Google Play Services, gå till enhetens inställningar. Felkod: %d</string>
     <string name="enable_err_generic">Okänt fel</string>
     <string name="enable_err_dismiss">Stäng</string>
-    <string name="enable_error_api_code">Det skedde ett oväntat fel, kod: %d</string>
+    <string name="enable_error_api_code">Det skedde ett oväntat fel, kod: %1$d (%2$d)</string>
 
     <string name="onboarding_done">Idrifttagningen klar!</string>
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -155,7 +155,7 @@
 
     <string name="enable_err_title">Exponeringsloggen kunde inte startas</string>
     <string name="enable_err_missing_capability">Din enhet stöds ej</string>
-    <string name="enable_err_api_not_supported">Din enhet stöder inte exponeringsmeddelanden. För att kontrollera versionen av Google Play Services, gå till enhetens inställningar. Felkod: %d</string>
+    <string name="enable_err_api_not_supported">Din enhet stöder inte exponeringsmeddelanden. För att kontrollera versionen av Google Play Services, gå till enhetens inställningar.\n\nFelkod: %d</string>
     <string name="enable_err_generic">Okänt fel</string>
     <string name="enable_err_dismiss">Stäng</string>
     <string name="enable_error_api_code">Det skedde ett oväntat fel, kod: %1$d (%2$d)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -155,7 +155,10 @@
 
     <string name="enable_err_title">Exponeringsloggen kunde inte startas</string>
     <string name="enable_err_missing_capability">Din enhet stöds ej</string>
-    <string name="enable_err_api_not_supported">Din enhet stöder inte exponeringsmeddelanden. För att kontrollera versionen av Google Play Services, gå till enhetens inställningar.\n\nFelkod: %d</string>
+    <string name="enable_err_api_not_supported">Din enhet stöder inte exponeringsmeddelanden av Google Play Services.\n\n%s</string>
+    <string name="enable_err_api_connection_device">Fel: Din enhet stöds ej</string>
+    <string name="enable_err_api_connection_unauthorized">Fel: Appen har inte tillstånd att använda exponeringsmeddelanden</string>
+    <string name="enable_err_api_connection_generic">Felkod: %d</string>
     <string name="enable_err_generic">Okänt fel</string>
     <string name="enable_err_dismiss">Stäng</string>
     <string name="enable_error_api_code">Det skedde ett oväntat fel, kod: %1$d (%2$d)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,7 +159,10 @@
 
     <string name="enable_err_title">Altistumisilmoitusten käynnistys epäonnistui</string>
     <string name="enable_err_missing_capability">Laitteesi ei ole tuettu</string>
-    <string name="enable_err_api_not_supported">Laitteesi ei tue altistumisilmoituksia. Tarkista Google Play Palveluiden versio laitteesi asetuksista.\n\nVirhekoodi: %d</string>
+    <string name="enable_err_api_not_supported">Valitettavasti Google Play Palveluiden altistumisilmoitukset eivät ole saatavilla laitteessasi.\n\n%s</string>
+    <string name="enable_err_api_connection_device">Virhe: Laitteesi ei ole tuettu</string>
+    <string name="enable_err_api_connection_unauthorized">Virhe: Altistumisilmoitukset eivät ole sallittu sovellukselle</string>
+    <string name="enable_err_api_connection_generic">Virhe: %d</string>
     <string name="enable_err_generic">Tuntematon virhe</string>
     <string name="enable_error_api_code">Tapahtui odottamaton virhe, koodi: %1$d (%2$d)</string>
     <string name="enable_err_dismiss">Sulje</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,7 +159,7 @@
 
     <string name="enable_err_title">Altistumisilmoitusten käynnistys epäonnistui</string>
     <string name="enable_err_missing_capability">Laitteesi ei ole tuettu</string>
-    <string name="enable_err_api_not_supported">Laitteesi ei tue altistumisilmoituksia. Tarkista Google Play Palveluiden versio laitteesi asetuksista. Yhteysvirheen koodi: %d</string>
+    <string name="enable_err_api_not_supported">Laitteesi ei tue altistumisilmoituksia. Tarkista Google Play Palveluiden versio laitteesi asetuksista.\n\nVirhekoodi: %d</string>
     <string name="enable_err_generic">Tuntematon virhe</string>
     <string name="enable_error_api_code">Tapahtui odottamaton virhe, koodi: %1$d (%2$d)</string>
     <string name="enable_err_dismiss">Sulje</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,10 +157,11 @@
     <string name="enable_alert">"Terveydestäsi ja läheistesi terveydestä huolehtimiseksi on suositeltavaa, että otat altistumisilmoitukset käyttöön heti kun mahdollista. "</string>
     <string name="enable_note">Ota COVID-19-altistumisilmoitukset käyttöön</string>
 
-    <string name="enable_err_title">Altistuslokin käynnistys epäonnistui</string>
+    <string name="enable_err_title">Altistumisilmoitusten käynnistys epäonnistui</string>
     <string name="enable_err_missing_capability">Laitteesi ei ole tuettu</string>
+    <string name="enable_err_api_not_supported">Laitteesi ei tue altistumisilmoituksia. Tarkista Google Play Palveluiden versio laitteesi asetuksista. Yhteysvirheen koodi: %d</string>
     <string name="enable_err_generic">Tuntematon virhe</string>
-    <string name="enable_error_api_code">Tapahtui odottamaton virhe, koodi: %d</string>
+    <string name="enable_error_api_code">Tapahtui odottamaton virhe, koodi: %1$d (%2$d)</string>
     <string name="enable_err_dismiss">Sulje</string>
 
     <string name="onboarding_done">Käyttöönotto valmis!</string>

--- a/app/src/test/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorkerTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorkerTest.kt
@@ -106,7 +106,7 @@ class DiagnosisKeyUpdateWorkerTest {
                 downloadResultWithFiles(listOf(File("")))
 
         coEvery { exposureNotificationService.provideDiagnosisKeyFiles(any(), any(), any()) } returns
-                ExposureNotificationService.ResolvableResult.Failed(1, "error")
+                ExposureNotificationService.ResolvableResult.Failed(1, 1, "error")
 
         runBlocking {
             val result = worker.startWork().get()

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         lifecycleVersion = '2.2.0'
         workVersion = '2.4.0'
         materialVersion = '1.2.0'
-        playVersion = '17.3.0'
+        playVersion = '17.4.0'
         roomVersion = '2.3.0-alpha02'
         retrofitVersion = '2.9.0'
         moshiVersion = '2.6.1'


### PR DESCRIPTION
When enabling exposure notifications
- Detect "device not supported" and "app not authorized" errors
- Show more detailed and specific error messages to user

This also updates play services dependency version