### PR TITLE
Handle missing browser error

### DIFF
--- a/app/src/main/java/fi/thl/koronahaavi/common/Extensions.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/common/Extensions.kt
@@ -18,6 +18,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import fi.thl.koronahaavi.R
 import fi.thl.koronahaavi.settings.GuideFragment
 import timber.log.Timber
 
@@ -33,7 +35,21 @@ fun Fragment.openLink(url: String) {
     val intent = Intent(Intent.ACTION_VIEW).apply {
         data = Uri.parse(url)
     }
-    startActivity(intent)
+
+    activity?.let {
+        if (intent.resolveActivity(it.packageManager) != null) {
+            startActivity(intent)
+        }
+        else {
+            // device does not have any apps that can open a web link, maybe
+            // browser app disabled, or profile restrictions in place
+            MaterialAlertDialogBuilder(it)
+                .setTitle(R.string.open_link_failed_title)
+                .setMessage(R.string.open_link_failed_message)
+                .setPositiveButton(R.string.all_ok, null)
+                .show()
+        }
+    }
 }
 
 fun FragmentActivity.openGuide() {

--- a/app/src/main/java/fi/thl/koronahaavi/exposure/PreWebContactFragment.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/exposure/PreWebContactFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import fi.thl.koronahaavi.BuildConfig
 import fi.thl.koronahaavi.R
 import fi.thl.koronahaavi.databinding.FragmentPreWebContactBinding
@@ -70,7 +71,21 @@ class PreWebContactFragment : Fragment() {
             .build()
 
         val intent = Intent(Intent.ACTION_VIEW).apply { data = uri }
-        startActivity(intent)
+
+        activity?.let {
+            if (intent.resolveActivity(it.packageManager) != null) {
+                startActivity(intent)
+            }
+            else {
+                // device does not have any apps that can open a web link, maybe
+                // browser app disabled, or profile restrictions in place
+                MaterialAlertDialogBuilder(it)
+                    .setTitle(R.string.omaolo_link_failed_title)
+                    .setMessage(R.string.omaolo_link_failed_message)
+                    .setPositiveButton(R.string.all_ok, null)
+                    .show()
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -217,7 +217,7 @@
     <string name="municipality_load_failed">Det gick inte att ladda kommunuppgifterna. Kontrollera anslutningen och försök på nytt.</string>
     <string name="municipality_retry_load">Försök på nytt</string>
 
-    <string name="open_link_failed_title">Linkkiä ei voitu avata</string>
-    <string name="open_link_failed_message">Valitsemaasi linkkiä ei voitu avata, sillä verkkoselainta ei voitu käynnistää. Laitteellasi ei ole selainohjelmaa tai sen käyttö on estetty.</string>
+    <string name="open_link_failed_title">Länken kunde inte öppnas</string>
+    <string name="open_link_failed_message">Länken kunde inte öppnas</string>
 
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -8,6 +8,7 @@
     <string name="all_yesterday">igår</string>
     <string name="all_app_additional_info">Se mer information om Coronablinkern</string>
     <string name="all_system_enable">Koppla på</string>
+    <string name="all_ok">OK</string>
 
     <string name="diagnosis_title">Meddela din smitta</string>
     <string name="diagnosis_body1">Om du har testats och konstaterats ha coronavirusinfektion får du en startkod från hälso- och sjukvården eller med ett textmeddelande från THL. Med startkoden kan du anonymt förmedla information om din smitta.</string>
@@ -210,7 +211,13 @@
     <string name="pre_web_contact_body_no_evaluation">Om du är symtomfri, kan du skicka en begäran till nättjänsten Omaolo.fi att du vill bli kontaktad. Välj kontaktspråk. Efter det här överförs du till nättjänsten Omaolo.fi.</string>
     <string name="pre_web_contact_title">Välj kontaktspråk</string>
 
+    <string name="omaolo_link_failed_title">Omaoloa ei voitu avata</string>
+    <string name="omaolo_link_failed_message">Koronavilkku ei voinut ohjata sinua Omaolo-palveluun, sillä verkkoselainta ei voitu käynnistää. Laitteellasi ei ole selainohjelmaa tai sen käyttö on estetty. Ole hyvä ja ota yhteys terveydenhuoltoon puhelimitse.</string>
+
     <string name="municipality_load_failed">Det gick inte att ladda kommunuppgifterna. Kontrollera anslutningen och försök på nytt.</string>
     <string name="municipality_retry_load">Försök på nytt</string>
+
+    <string name="open_link_failed_title">Linkkiä ei voitu avata</string>
+    <string name="open_link_failed_message">Valitsemaasi linkkiä ei voitu avata, sillä verkkoselainta ei voitu käynnistää. Laitteellasi ei ole selainohjelmaa tai sen käyttö on estetty.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="all_english" translatable="false">English</string>
     <string name="all_app_additional_info">Katso lisätietoa Koronavilkusta</string>
     <string name="all_system_enable">Ota käyttöön</string>
+    <string name="all_ok">OK</string>
 
     <string name="diagnosis_title">Ilmoita tartunnastasi</string>
     <string name="diagnosis_body1">Jos sinulla todetaan tartunta koronavirustestillä, saat avauskoodin terveydenhuollon ammattilaiselta tai tekstiviestillä THL:ltä. Avauskoodilla voit jakaa nimettömästi tiedon tartunnastasi.</string>
@@ -228,7 +229,13 @@
     <string name="pre_web_contact_body_no_evaluation">Jos olet oireeton, voit lähettää yhteydenottopyynnön Omaolo.fi-verkkopalvelussa. Valitse asiointikieli. Tämän jälkeen siirryt Omaolo.fi-verkkopalveluun.</string>
     <string name="pre_web_contact_title">Valitse asiointikieli</string>
 
+    <string name="omaolo_link_failed_title">Omaoloa ei voitu avata</string>
+    <string name="omaolo_link_failed_message">Koronavilkku ei voinut ohjata sinua Omaolo-palveluun, sillä verkkoselainta ei voitu käynnistää. Laitteellasi ei ole selainohjelmaa tai sen käyttö on estetty. Ole hyvä ja ota yhteys terveydenhuoltoon puhelimitse.</string>
+
     <string name="municipality_load_failed">Kuntatietojen lataus epäonnistui. Tarkista verkkoyhteys ja yritä uudelleen.</string>
     <string name="municipality_retry_load">Yritä uudelleen</string>
+
+    <string name="open_link_failed_title">Linkkiä ei voitu avata</string>
+    <string name="open_link_failed_message">Valitsemaasi linkkiä ei voitu avata, sillä verkkoselainta ei voitu käynnistää. Laitteellasi ei ole selainohjelmaa tai sen käyttö on estetty.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,13 +229,13 @@
     <string name="pre_web_contact_body_no_evaluation">Jos olet oireeton, voit lähettää yhteydenottopyynnön Omaolo.fi-verkkopalvelussa. Valitse asiointikieli. Tämän jälkeen siirryt Omaolo.fi-verkkopalveluun.</string>
     <string name="pre_web_contact_title">Valitse asiointikieli</string>
 
-    <string name="omaolo_link_failed_title">Omaoloa ei voitu avata</string>
-    <string name="omaolo_link_failed_message">Koronavilkku ei voinut ohjata sinua Omaolo-palveluun, sillä verkkoselainta ei voitu käynnistää. Laitteellasi ei ole selainohjelmaa tai sen käyttö on estetty. Ole hyvä ja ota yhteys terveydenhuoltoon puhelimitse.</string>
+    <string name="omaolo_link_failed_title">Omaoloa ei voida avata</string>
+    <string name="omaolo_link_failed_message">Koronavilkku ei voi ohjata sinua Omaolo-palveluun, koska puhelimessasi ei ole selainta tai sen käyttö on estetty. Ole hyvä ja ota yhteys terveydenhuoltoon puhelimitse.</string>
 
     <string name="municipality_load_failed">Kuntatietojen lataus epäonnistui. Tarkista verkkoyhteys ja yritä uudelleen.</string>
     <string name="municipality_retry_load">Yritä uudelleen</string>
 
-    <string name="open_link_failed_title">Linkkiä ei voitu avata</string>
-    <string name="open_link_failed_message">Valitsemaasi linkkiä ei voitu avata, sillä verkkoselainta ei voitu käynnistää. Laitteellasi ei ole selainohjelmaa tai sen käyttö on estetty.</string>
+    <string name="open_link_failed_title">Verkkosivua ei voida avata</string>
+    <string name="open_link_failed_message">Verkkosivua ei voida avata, koska puhelimessasi ei ole selainta tai sen käyttö on estetty.</string>
 
 </resources>


### PR DESCRIPTION
If device does not have an app capable of handling URL display (browser disabled or prevented), show an error dialog when trying to open a link