### PR TITLE
Do not check location when not required by exposure notifications

### DIFF
--- a/app/src/live/java/fi/thl/koronahaavi/device/DeviceStateRepository.kt
+++ b/app/src/live/java/fi/thl/koronahaavi/device/DeviceStateRepository.kt
@@ -2,15 +2,22 @@ package fi.thl.koronahaavi.device
 
 import android.content.Context
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.qualifiers.ApplicationContext
+import fi.thl.koronahaavi.service.ExposureNotificationService
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class DeviceStateRepository @Inject constructor (
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val exposureNotificationService: ExposureNotificationService
 ) {
     fun bluetoothOn(): LiveData<Boolean> = BluetoothOnLiveData(context)
 
-    fun locationOn(): LiveData<Boolean> = LocationOnLiveData(context)
+    fun locationOn(): LiveData<Boolean> =
+        if (exposureNotificationService.deviceSupportsLocationlessScanning())
+            MutableLiveData(true) // always on since EN does not care
+        else
+            LocationOnLiveData(context)
 }

--- a/app/src/main/java/fi/thl/koronahaavi/service/ExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/ExposureNotificationService.kt
@@ -22,6 +22,7 @@ interface ExposureNotificationService {
     suspend fun getExposureDetails(token: String): List<ExposureInformation>
     suspend fun provideDiagnosisKeyFiles(token: String, files: List<File>, config: ExposureConfigurationData): ResolvableResult<Unit>
     suspend fun getTemporaryExposureKeys(): ResolvableResult<List<TemporaryExposureKey>>
+    fun deviceSupportsLocationlessScanning(): Boolean
 
     fun isEnabledFlow() : StateFlow<Boolean?>
     suspend fun refreshEnabledFlow()

--- a/app/src/main/java/fi/thl/koronahaavi/service/FakeExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/FakeExposureNotificationService.kt
@@ -96,6 +96,8 @@ class FakeExposureNotificationService(
         ))
     }
 
+    override fun deviceSupportsLocationlessScanning() = false
+
     private fun fakeExposureKey() = TemporaryExposureKeyBuilder()
         .setKeyData(Random.nextBytes(16))
         .setRollingPeriod(144)

--- a/app/src/main/java/fi/thl/koronahaavi/service/GoogleExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/GoogleExposureNotificationService.kt
@@ -76,6 +76,8 @@ class GoogleExposureNotificationService(
         client.temporaryExposureKeyHistory.await()
     }
 
+    override fun deviceSupportsLocationlessScanning() = client.deviceSupportsLocationlessScanning()
+
     private suspend fun <T> resultFromRunning(block: suspend () -> T): ResolvableResult<T> {
         try {
             return ResolvableResult.Success(block())


### PR DESCRIPTION
Ignore device location setting for app status when not required by exposure notification API. This support was added in Android 11, but the app gets this information through exposure notification API instead of checking for Android version.