### PR TITLE
Periodically clear old diagnosis key group tokens 

### DIFF
--- a/app/src/androidTest/java/fi/thl/koronahaavi/FakeExposureRepository.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/FakeExposureRepository.kt
@@ -8,6 +8,9 @@ import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 class FakeExposureRepository : ExposureRepository {
+    override suspend fun getAllKeyGroupTokens(): List<KeyGroupToken>
+            = listOf()
+
     override suspend fun saveKeyGroupToken(token: KeyGroupToken) {
     }
 

--- a/app/src/androidTest/java/fi/thl/koronahaavi/data/KeyGroupTokenDaoTest.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/data/KeyGroupTokenDaoTest.kt
@@ -1,0 +1,71 @@
+package fi.thl.koronahaavi.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.ZonedDateTime
+
+@RunWith(AndroidJUnit4::class)
+class KeyGroupTokenDaoTest {
+    private lateinit var db: AppDatabase
+    private lateinit var keyGroupTokenDao: KeyGroupTokenDao
+
+    @Before
+    fun init() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        keyGroupTokenDao = db.keyGroupTokenDao()
+    }
+
+    @After
+    fun cleanup() {
+        db.close()
+    }
+
+    @Test
+    fun writeAndUpdateToken() {
+        val token = KeyGroupToken("a")
+        runBlocking {
+            keyGroupTokenDao.insert(token)
+
+            val updateToken = token.copy(updatedDate = ZonedDateTime.now(), matchedKeyCount = 1, maximumRiskScore = 200)
+            keyGroupTokenDao.insert(updateToken)
+
+            val tokens = keyGroupTokenDao.getAll()
+            Assert.assertEquals(1, tokens.size)
+            Assert.assertEquals(token.token, tokens[0].token)
+        }
+    }
+
+    @Test
+    fun deleteTokens() {
+        val tokenA = KeyGroupToken("a")
+        val tokenB = KeyGroupToken("b")
+        val tokenC = KeyGroupToken("c")
+
+        runBlocking {
+            keyGroupTokenDao.insert(tokenA)
+            keyGroupTokenDao.insert(tokenB)
+            keyGroupTokenDao.insert(tokenC)
+
+            val updateTokenA = tokenA.copy(updatedDate = ZonedDateTime.now(), matchedKeyCount = 1, maximumRiskScore = 100)
+            keyGroupTokenDao.insert(updateTokenA)
+
+            val updateTokenB = tokenB.copy(updatedDate = ZonedDateTime.now(), matchedKeyCount = 2, maximumRiskScore = 200)
+            keyGroupTokenDao.insert(updateTokenB)
+
+            keyGroupTokenDao.delete(tokenA, tokenB)
+
+            val tokens = keyGroupTokenDao.getAll()
+            Assert.assertEquals(1, tokens.size)
+            Assert.assertEquals(tokenC.token, tokens[0].token)
+        }
+    }
+}

--- a/app/src/main/java/fi/thl/koronahaavi/data/DefaultExposureRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/DefaultExposureRepository.kt
@@ -8,6 +8,9 @@ class DefaultExposureRepository (
     private val exposureDao: ExposureDao
 ) : ExposureRepository {
 
+    override suspend fun getAllKeyGroupTokens(): List<KeyGroupToken>
+            = keyGroupTokenDao.getAll()
+
     override suspend fun saveKeyGroupToken(token: KeyGroupToken)
             = keyGroupTokenDao.insert(token)
 

--- a/app/src/main/java/fi/thl/koronahaavi/data/ExposureRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/ExposureRepository.kt
@@ -3,6 +3,7 @@ package fi.thl.koronahaavi.data
 import kotlinx.coroutines.flow.Flow
 
 interface ExposureRepository {
+    suspend fun getAllKeyGroupTokens(): List<KeyGroupToken>
     suspend fun saveKeyGroupToken(token: KeyGroupToken)
     fun flowHandledKeyGroupTokens(): Flow<List<KeyGroupToken>>
     suspend fun deleteKeyGroupToken(token: KeyGroupToken)

--- a/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupTokenDao.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupTokenDao.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface KeyGroupTokenDao {
 
+    @Query("SELECT * FROM key_group_token")
+    suspend fun getAll(): List<KeyGroupToken>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(token: KeyGroupToken)
 

--- a/app/src/main/java/fi/thl/koronahaavi/exposure/ClearExpiredExposuresWorker.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/exposure/ClearExpiredExposuresWorker.kt
@@ -31,6 +31,14 @@ class ClearExpiredExposuresWorker @WorkerInject constructor(
                 exposureRepository.deleteExposure(it.id)
             }
         }
+
+        exposureRepository.getAllKeyGroupTokens().forEach {
+            if (it.updatedDate.isBefore(expireTime)) {
+                Timber.d("Deleting key group updated ${it.updatedDate}")
+                exposureRepository.deleteKeyGroupToken(it)
+            }
+        }
+
         return Result.success()
     }
 


### PR DESCRIPTION
Modifies ClearExpiredExposuresWorker so that it also clears expired key group tokens which are identifiers for each downloaded key file batch.