### PR TITLE
Reschedule update worker on app create

### DIFF
--- a/app/src/main/java/fi/thl/koronahaavi/VilkkuApplication.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/VilkkuApplication.kt
@@ -37,12 +37,7 @@ class VilkkuApplication : Application() {
         // This is an additional check to make sure workers are scheduled in case
         // app was force-stopped from background and woken up by EN api service.
         if (appStateRepository.isOnboardingComplete()) {
-            workDispatcher.scheduleWorkers(reconfigure = isLastExposureCheckOld())
+            workDispatcher.scheduleWorkers(reconfigureStale = true)
         }
-    }
-
-    private fun isLastExposureCheckOld(): Boolean {
-        val limit = ZonedDateTime.now().minusHours(4)
-        return appStateRepository.lastExposureCheckTimeLatest()?.isBefore(limit) != false
     }
 }

--- a/app/src/main/java/fi/thl/koronahaavi/VilkkuApplication.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/VilkkuApplication.kt
@@ -9,6 +9,7 @@ import fi.thl.koronahaavi.data.AppStateRepository
 import fi.thl.koronahaavi.service.WorkDispatcher
 import timber.log.Timber
 import timber.log.Timber.DebugTree
+import java.time.ZonedDateTime
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -36,7 +37,12 @@ class VilkkuApplication : Application() {
         // This is an additional check to make sure workers are scheduled in case
         // app was force-stopped from background and woken up by EN api service.
         if (appStateRepository.isOnboardingComplete()) {
-            workDispatcher.scheduleWorkers()
+            workDispatcher.scheduleWorkers(reconfigure = isLastExposureCheckOld())
         }
+    }
+
+    private fun isLastExposureCheckOld(): Boolean {
+        val limit = ZonedDateTime.now().minusHours(4)
+        return appStateRepository.lastExposureCheckTimeLatest()?.isBefore(limit) != false
     }
 }

--- a/app/src/main/java/fi/thl/koronahaavi/data/AppStateRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/AppStateRepository.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import fi.thl.koronahaavi.service.BackendService
 import fi.thl.koronahaavi.service.BatchId
-import fi.thl.koronahaavi.service.WorkDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.time.Instant
@@ -17,8 +16,7 @@ import javax.inject.Singleton
 @Singleton
 class AppStateRepository @Inject constructor (
     private val prefs: SharedPreferences,
-    private val backendService: BackendService,
-    private val workDispatcher: WorkDispatcher
+    private val backendService: BackendService
 ) {
     private val onBoardingCompleteKey = "onboarding_complete"
     private val lastBatchIdKey = "last_batch_id"
@@ -50,10 +48,6 @@ class AppStateRepository @Inject constructor (
     fun setDiagnosisKeysSubmitted(submitted: Boolean) {
         keysSubmitted.value = submitted
         prefs.edit().putBoolean(diagnosisKeysSubmittedKey, submitted).apply()
-
-        if (submitted) {
-            workDispatcher.cancelWorkersAfterLock()
-        }
     }
 
      private fun updateLastExposureCheckTime() {

--- a/app/src/main/java/fi/thl/koronahaavi/data/AppStateRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/AppStateRepository.kt
@@ -31,11 +31,21 @@ class AppStateRepository @Inject constructor (
     fun lockedAfterDiagnosis(): StateFlow<Boolean> = keysSubmitted
 
     private val lastExposureCheckTime = MutableLiveData<ZonedDateTime?>(null)
-    fun lastExposureCheckTime(): LiveData<ZonedDateTime?> = lastExposureCheckTime
-
-    init {
-        updateLastExposureCheckTime()
+    fun lastExposureCheckTime(): LiveData<ZonedDateTime?> {
+        if (lastExposureCheckTime.value == null) {
+            updateLastExposureCheckTime() // initial value set when livedata used
+        }
+        return lastExposureCheckTime
     }
+
+    fun lastExposureCheckTimeLatest(): ZonedDateTime? =
+        if (prefs.contains(lastExposureCheckTimeKey)) {
+            val epochSec = prefs.getLong(lastExposureCheckTimeKey, 0)
+            ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSec), ZoneId.systemDefault())
+        }
+        else {
+            null
+        }
 
     fun setDiagnosisKeysSubmitted(submitted: Boolean) {
         keysSubmitted.value = submitted
@@ -47,15 +57,7 @@ class AppStateRepository @Inject constructor (
     }
 
      private fun updateLastExposureCheckTime() {
-        lastExposureCheckTime.postValue(
-            if (prefs.contains(lastExposureCheckTimeKey)) {
-                val epochSec = prefs.getLong(lastExposureCheckTimeKey, 0)
-                ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSec), ZoneId.systemDefault())
-            }
-            else {
-                null
-            }
-        )
+        lastExposureCheckTime.postValue(lastExposureCheckTimeLatest())
     }
 
     fun setLastExposureCheckTime(time: ZonedDateTime) {

--- a/app/src/main/java/fi/thl/koronahaavi/data/AppStateRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/AppStateRepository.kt
@@ -29,14 +29,14 @@ class AppStateRepository @Inject constructor (
     fun lockedAfterDiagnosis(): StateFlow<Boolean> = keysSubmitted
 
     private val lastExposureCheckTime = MutableLiveData<ZonedDateTime?>(null)
-    fun lastExposureCheckTime(): LiveData<ZonedDateTime?> {
+    fun getLastExposureCheckTimeLive(): LiveData<ZonedDateTime?> {
         if (lastExposureCheckTime.value == null) {
             updateLastExposureCheckTime() // initial value set when livedata used
         }
         return lastExposureCheckTime
     }
 
-    fun lastExposureCheckTimeLatest(): ZonedDateTime? =
+    fun getLastExposureCheckTime(): ZonedDateTime? =
         if (prefs.contains(lastExposureCheckTimeKey)) {
             val epochSec = prefs.getLong(lastExposureCheckTimeKey, 0)
             ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSec), ZoneId.systemDefault())
@@ -51,7 +51,7 @@ class AppStateRepository @Inject constructor (
     }
 
      private fun updateLastExposureCheckTime() {
-        lastExposureCheckTime.postValue(lastExposureCheckTimeLatest())
+        lastExposureCheckTime.postValue(getLastExposureCheckTime())
     }
 
     fun setLastExposureCheckTime(time: ZonedDateTime) {

--- a/app/src/main/java/fi/thl/koronahaavi/diagnosis/CodeEntryViewModel.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/diagnosis/CodeEntryViewModel.kt
@@ -16,6 +16,7 @@ class CodeEntryViewModel @ViewModelInject constructor(
     private val exposureNotificationService: ExposureNotificationService,
     private val diagnosisKeyService: DiagnosisKeyService,
     private val appStateRepository: AppStateRepository,
+    private val workDispatcher: WorkDispatcher,
     settingsRepository: SettingsRepository
 ) : ViewModel() {
 
@@ -107,7 +108,8 @@ class CodeEntryViewModel @ViewModelInject constructor(
                 codeEntryError.removeSource(lockedAfterDiagnosis)
                 codeEntryError.removeSource(enEnabled)
 
-                appStateRepository.setDiagnosisKeysSubmitted(true) // also stops the update worker
+                appStateRepository.setDiagnosisKeysSubmitted(true)
+                workDispatcher.cancelWorkersAfterLock()
                 exposureNotificationService.disable()
                 keysSubmittedEvent.postValue(Event(true))
             }

--- a/app/src/main/java/fi/thl/koronahaavi/exposure/ClearExpiredExposuresWorker.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/exposure/ClearExpiredExposuresWorker.kt
@@ -48,12 +48,14 @@ class ClearExpiredExposuresWorker @WorkerInject constructor(
         const val EXPOSURE_TTL_SINCE_DETECTION_DAYS = 11
         const val CLEAR_EXPIRED_WORKER_NAME = "ClearExpiredExposuresWorker"
 
-        fun schedule(context: Context) {
+        fun schedule(context: Context, reconfigure: Boolean = false) {
             val request = PeriodicWorkRequestBuilder<ClearExpiredExposuresWorker>(12, TimeUnit.HOURS)
                 .build()
 
+            val policy = if (reconfigure) ExistingPeriodicWorkPolicy.REPLACE else ExistingPeriodicWorkPolicy.KEEP
+
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                CLEAR_EXPIRED_WORKER_NAME, ExistingPeriodicWorkPolicy.KEEP, request
+                CLEAR_EXPIRED_WORKER_NAME, policy, request
             )
         }
     }

--- a/app/src/main/java/fi/thl/koronahaavi/exposure/ExposureDetailViewModel.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/exposure/ExposureDetailViewModel.kt
@@ -10,6 +10,6 @@ class ExposureDetailViewModel @ViewModelInject constructor(
     appStateRepository: AppStateRepository
 ) : ViewModel() {
     val hasExposures = exposureRepository.flowHasExposures().asLiveData()
-    val lastCheckTime = appStateRepository.lastExposureCheckTime()
+    val lastCheckTime = appStateRepository.getLastExposureCheckTimeLive()
 }
 

--- a/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
@@ -44,6 +44,6 @@ class WorkDispatcher @Inject constructor(
         val intervalMinutes = settingsRepository.appConfiguration.pollingIntervalMinutes
         val limit = ZonedDateTime.now().minusMinutes(2 * intervalMinutes)
 
-        return appStateRepository.lastExposureCheckTimeLatest()?.isBefore(limit) != false
+        return appStateRepository.getLastExposureCheckTime()?.isBefore(limit) != false
     }
 }

--- a/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
@@ -31,10 +31,10 @@ class WorkDispatcher @Inject constructor(
         // Attempting to trigger worker to execute by reconfiguring at app startup
         val reconfigure = reconfigureStale && isLastExposureCheckOld()
         DiagnosisKeyUpdateWorker.schedule(context, settingsRepository.appConfiguration, reconfigure)
+        ClearExpiredExposuresWorker.schedule(context, reconfigure)
 
         MunicipalityUpdateWorker.schedule(context)
         DiagnosisKeySendTrafficCoverWorker.schedule(context)
-        ClearExpiredExposuresWorker.schedule(context)
     }
 
     private fun isLastExposureCheckOld(): Boolean {

--- a/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
@@ -38,8 +38,11 @@ class WorkDispatcher @Inject constructor(
     }
 
     private fun isLastExposureCheckOld(): Boolean {
+        // last check is considered old if it's been longer than two update intervals, because
+        // work manager execution is not exact, and we do not want to always update on process start
+        // since that would give the impression that updates never work on the background
         val intervalMinutes = settingsRepository.appConfiguration.pollingIntervalMinutes
-        val limit = ZonedDateTime.now().minusMinutes(intervalMinutes)
+        val limit = ZonedDateTime.now().minusMinutes(2 * intervalMinutes)
 
         return appStateRepository.lastExposureCheckTimeLatest()?.isBefore(limit) != false
     }

--- a/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
@@ -29,6 +29,9 @@ class WorkDispatcher @Inject constructor(
 
     fun scheduleWorkers(reconfigureStale: Boolean = false) {
         // Attempting to trigger worker to execute by reconfiguring at app startup
+        // This seems to be required on some android models, like Xiaomi, to execute worker
+        // when Google services periodically restart the app process using WakeUpService
+
         val reconfigure = reconfigureStale && isLastExposureCheckOld()
         DiagnosisKeyUpdateWorker.schedule(context, settingsRepository.appConfiguration, reconfigure)
         ClearExpiredExposuresWorker.schedule(context, reconfigure)

--- a/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/WorkDispatcher.kt
@@ -24,8 +24,10 @@ class WorkDispatcher @Inject constructor(
         }
     }
 
-    fun scheduleWorkers() {
-        DiagnosisKeyUpdateWorker.schedule(context, settingsRepository.appConfiguration)
+    fun scheduleWorkers(reconfigure: Boolean = false) {
+        // Attempting to trigger worker to execute by reconfiguring at app startup
+        DiagnosisKeyUpdateWorker.schedule(context, settingsRepository.appConfiguration, reconfigure)
+
         MunicipalityUpdateWorker.schedule(context)
         DiagnosisKeySendTrafficCoverWorker.schedule(context)
         ClearExpiredExposuresWorker.schedule(context)

--- a/app/src/test/java/fi/thl/koronahaavi/diagnosis/CodeEntryViewModelTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/diagnosis/CodeEntryViewModelTest.kt
@@ -11,6 +11,7 @@ import fi.thl.koronahaavi.service.ExposureNotificationService
 import fi.thl.koronahaavi.service.ExposureNotificationService.ResolvableResult.ResolutionRequired
 import fi.thl.koronahaavi.service.ExposureNotificationService.ResolvableResult.Success
 import fi.thl.koronahaavi.service.SendKeysResult
+import fi.thl.koronahaavi.service.WorkDispatcher
 import fi.thl.koronahaavi.utils.MainCoroutineScopeRule
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -33,6 +34,7 @@ class CodeEntryViewModelTest {
     private lateinit var exposureNotificationService: ExposureNotificationService
     private lateinit var appStateRepository: AppStateRepository
     private lateinit var settingsRepository: SettingsRepository
+    private lateinit var workDispatcher: WorkDispatcher
 
     val enEnabledFlow = MutableStateFlow(false)
 
@@ -42,12 +44,13 @@ class CodeEntryViewModelTest {
         exposureNotificationService = mockk(relaxed = true)
         appStateRepository = mockk(relaxed = true)
         settingsRepository = mockk(relaxed = true)
+        workDispatcher = mockk(relaxed = true)
 
         coEvery { exposureNotificationService.isEnabledFlow() } returns enEnabledFlow
         coEvery { exposureNotificationService.getTemporaryExposureKeys() } returns Success(listOf())
         coEvery { diagnosisKeyService.sendExposureKeys(any(), any()) } returns SendKeysResult.Success
 
-        viewModel = CodeEntryViewModel(exposureNotificationService, diagnosisKeyService, appStateRepository, settingsRepository)
+        viewModel = CodeEntryViewModel(exposureNotificationService, diagnosisKeyService, appStateRepository, workDispatcher, settingsRepository)
     }
 
     @Test


### PR DESCRIPTION
If background exposure updates have not been executed (due to doze and power saving modes), reschedule update worker during app process start. This triggers update worker to execute.