### PR TITLE
Modify exposure notification list to use specific data entity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,6 +142,11 @@ android {
         }
     }
 
+    sourceSets {
+        // Database schema required for migration testing
+        androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
+    }
+
     testOptions.unitTests.includeAndroidResources = true
 }
 
@@ -190,7 +195,6 @@ dependencies {
     implementation "androidx.room:room-runtime:$roomVersion"
     implementation "androidx.room:room-ktx:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
-    testImplementation "androidx.room:room-testing:$roomVersion"
 
     // Google Play (also aar file included from libs folder)
     implementation "com.google.android.gms:play-services-base:$playVersion"
@@ -232,6 +236,7 @@ dependencies {
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$hiltVersion"
     androidTestImplementation "androidx.work:work-testing:$workVersion"
     androidTestImplementation "androidx.navigation:navigation-testing:$navigationVersion"
+    androidTestImplementation "androidx.room:room-testing:$roomVersion"
 }
 
 if (gradle.getStartParameter().getTaskRequests().toString().toLowerCase().contains("huawei")) {

--- a/app/schemas/fi.thl.koronahaavi.data.AppDatabase/4.json
+++ b/app/schemas/fi.thl.koronahaavi.data.AppDatabase/4.json
@@ -1,0 +1,102 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "ec4f84dc8edb7d2ac7a76a242ba9fa81",
+    "entities": [
+      {
+        "tableName": "key_group_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`token` TEXT NOT NULL, `updated_date` INTEGER NOT NULL, `matched_key_count` INTEGER, `maximum_risk_score` INTEGER, `exposure_count` INTEGER, `latest_exposure_date` INTEGER, PRIMARY KEY(`token`))",
+        "fields": [
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedDate",
+            "columnName": "updated_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedKeyCount",
+            "columnName": "matched_key_count",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maximumRiskScore",
+            "columnName": "maximum_risk_score",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "exposureCount",
+            "columnName": "exposure_count",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latestExposureDate",
+            "columnName": "latest_exposure_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "token"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "exposure",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `detected_date` INTEGER NOT NULL, `created_date` INTEGER NOT NULL, `total_risk_score` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detectedDate",
+            "columnName": "detected_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdDate",
+            "columnName": "created_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalRiskScore",
+            "columnName": "total_risk_score",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ec4f84dc8edb7d2ac7a76a242ba9fa81')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/fi/thl/koronahaavi/AppHomeTest.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/AppHomeTest.kt
@@ -1,0 +1,160 @@
+package fi.thl.koronahaavi
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import androidx.work.Configuration
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import fi.thl.koronahaavi.data.*
+import fi.thl.koronahaavi.di.AppModule
+import fi.thl.koronahaavi.di.ExposureNotificationModule
+import fi.thl.koronahaavi.di.NetworkModule
+import fi.thl.koronahaavi.settings.UserPreferences
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.time.ZonedDateTime
+import java.util.*
+import javax.inject.Inject
+
+/**
+ * Test app home screen with database and repository
+ */
+@UninstallModules(AppModule::class, NetworkModule::class, ExposureNotificationModule::class, TestRepositoryModule::class)
+@HiltAndroidTest
+class AppHomeTest {
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val activityRule = ActivityTestRule(MainActivity::class.java, false, false)
+
+    @Inject
+    lateinit var appStateRepository: AppStateRepository
+
+    @Inject
+    lateinit var userPreferences: UserPreferences
+
+    @Inject
+    lateinit var exposureDao: ExposureDao
+
+    @Inject
+    lateinit var keyGroupTokenDao: KeyGroupTokenDao
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+
+        WorkManagerTestInitHelper.initializeTestWorkManager(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            Configuration.Builder().setExecutor(SynchronousExecutor()).build()
+        )
+
+        // disable power disable prompts
+        userPreferences.powerOptimizationDisableAllowed = false
+
+        runBlocking {
+            exposureDao.deleteAll()
+            keyGroupTokenDao.deleteAll()
+        }
+    }
+
+    @Test
+    fun legacyExposure() {
+        appStateRepository.setOnboardingComplete(true)
+        activityRule.launchActivity(null)
+        onView(withId(R.id.image_home_app_status)).checkIsDisplayed()
+        onView(withId(R.id.button_home_exposure_instructions)).checkIsGone()
+
+        runBlocking {
+            val token = "test"
+            val exposure = insertTokenAndExposure(token)
+
+            // this update is done when exposure data received
+            keyGroupTokenDao.insert(KeyGroupToken(
+                    token = token,
+                    matchedKeyCount = 1,
+                    maximumRiskScore = exposure.totalRiskScore
+            ))
+
+            delay(1000) // data binding
+            onView(withId(R.id.button_home_exposure_instructions)).checkIsDisplayed()
+            onView(withId(R.id.text_home_exposure_notification_count)).checkIsDisplayed()
+            onView(withId(R.id.text_home_exposure_notification_count)).checkHasText(R.string.home_notifications_unknown)
+        }
+    }
+
+    @Test
+    fun singleExposureNotification() {
+        appStateRepository.setOnboardingComplete(true)
+        activityRule.launchActivity(null)
+        onView(withId(R.id.image_home_app_status)).checkIsDisplayed()
+        onView(withId(R.id.button_home_exposure_instructions)).checkIsGone()
+
+        runBlocking {
+            val token = "test"
+            val exposure = insertTokenAndExposure(token)
+
+            keyGroupTokenDao.insert(KeyGroupToken(
+                    token = token,
+                    matchedKeyCount = 1,
+                    maximumRiskScore = exposure.totalRiskScore,
+                    exposureCount = 1,
+                    latestExposureDate = exposure.detectedDate
+            ))
+
+            delay(1000) // data binding
+            onView(withId(R.id.button_home_exposure_instructions)).checkIsDisplayed()
+            onView(withId(R.id.text_home_exposure_notification_count)).checkIsDisplayed()
+            onView(withId(R.id.text_home_exposure_notification_count)).checkHasText("1")
+        }
+    }
+
+    @Test
+    fun multipleExposureNotifications() {
+        appStateRepository.setOnboardingComplete(true)
+        activityRule.launchActivity(null)
+        onView(withId(R.id.image_home_app_status)).checkIsDisplayed()
+        onView(withId(R.id.button_home_exposure_instructions)).checkIsGone()
+
+        runBlocking {
+            repeat(2) {
+                val token = UUID.randomUUID().toString()
+                val exposure = insertTokenAndExposure(token)
+
+                keyGroupTokenDao.insert(KeyGroupToken(
+                        token = token,
+                        matchedKeyCount = 1,
+                        maximumRiskScore = exposure.totalRiskScore,
+                        exposureCount = 1,
+                        latestExposureDate = exposure.detectedDate
+                ))
+            }
+
+            delay(1000) // data binding
+            onView(withId(R.id.button_home_exposure_instructions)).checkIsDisplayed()
+            onView(withId(R.id.text_home_exposure_notification_count)).checkIsDisplayed()
+            onView(withId(R.id.text_home_exposure_notification_count)).checkHasText("2")
+        }
+    }
+
+    // insert the data that is created when diagnosis file is downloaded and exposure detected
+    private suspend fun insertTokenAndExposure(token: String): Exposure {
+        keyGroupTokenDao.insert(KeyGroupToken(token))
+
+        val exposure = Exposure(
+                detectedDate = ZonedDateTime.now().minusDays(4),
+                createdDate = ZonedDateTime.now(),
+                totalRiskScore = 200
+        )
+        exposureDao.insert(exposure)
+        return exposure
+    }
+}

--- a/app/src/androidTest/java/fi/thl/koronahaavi/FakeExposureRepository.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/FakeExposureRepository.kt
@@ -34,6 +34,6 @@ class FakeExposureRepository : ExposureRepository {
     override suspend fun deleteExpiredExposuresAndTokens() {
     }
 
-    override fun flowAllExposures(): Flow<List<Exposure>> = flowOf(listOf())
-    override fun flowExposureNotifications(): Flow<List<ExposureNotification>> = flowOf(listOf())
+    override fun getIsExposedFlow(): Flow<Boolean> = flowOf(false)
+    override fun getExposureNotificationsFlow(): Flow<List<ExposureNotification>> = flowOf(listOf())
 }

--- a/app/src/androidTest/java/fi/thl/koronahaavi/FakeExposureRepository.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/FakeExposureRepository.kt
@@ -19,6 +19,9 @@ class FakeExposureRepository : ExposureRepository {
     override suspend fun deleteKeyGroupToken(token: KeyGroupToken) {
     }
 
+    override suspend fun deleteAllKeyGroupTokens() {
+    }
+
     override suspend fun saveExposure(exposure: Exposure) {
     }
 

--- a/app/src/androidTest/java/fi/thl/koronahaavi/TestModule.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/TestModule.kt
@@ -49,12 +49,6 @@ object TestModule {
         return context.getSharedPreferences(TEST_SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
     }
 
-    @Singleton
-    @Provides
-    fun provideExposureRepository(): ExposureRepository {
-        return FakeExposureRepository()
-    }
-
     @Singleton @Provides @DatabaseName
     fun databaseName() = "koronavilkku-test-db"
 

--- a/app/src/androidTest/java/fi/thl/koronahaavi/TestRepositoryModule.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/TestRepositoryModule.kt
@@ -1,0 +1,20 @@
+package fi.thl.koronahaavi
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ApplicationComponent
+import fi.thl.koronahaavi.data.ExposureRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(ApplicationComponent::class)
+object TestRepositoryModule {
+
+    @Singleton
+    @Provides
+    fun provideExposureRepository(): ExposureRepository {
+        return FakeExposureRepository()
+    }
+}
+

--- a/app/src/androidTest/java/fi/thl/koronahaavi/data/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/data/AppDatabaseTest.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import fi.thl.koronahaavi.TestModule
+import fi.thl.koronahaavi.TestRepositoryModule
 import fi.thl.koronahaavi.di.AppModule
 import fi.thl.koronahaavi.di.DatabaseModule
 import fi.thl.koronahaavi.di.ExposureNotificationModule
@@ -17,7 +18,7 @@ import net.sqlcipher.database.SQLiteException
 import org.junit.*
 import javax.inject.Inject
 
-@UninstallModules(AppModule::class, NetworkModule::class, ExposureNotificationModule::class)
+@UninstallModules(AppModule::class, NetworkModule::class, ExposureNotificationModule::class, TestRepositoryModule::class)
 @HiltAndroidTest
 class AppDatabaseTest {
     @get:Rule

--- a/app/src/androidTest/java/fi/thl/koronahaavi/data/MigrationTest.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/data/MigrationTest.kt
@@ -1,0 +1,44 @@
+package fi.thl.koronahaavi.data
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import fi.thl.koronahaavi.di.DatabaseModule
+import org.junit.*
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+    private val testDatabase = "migration-test"
+    private val allMigrations = arrayOf(DatabaseModule.migrationThreeToFour)
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java.canonicalName,
+        FrameworkSQLiteOpenHelperFactory()
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrateAll() {
+        // Create earliest version of the database.
+        helper.createDatabase(testDatabase, 3).apply {
+            close()
+        }
+
+        // Open latest version of the database. Room will validate the schema
+        // once all migrations execute.
+        Room.databaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            AppDatabase::class.java,
+            testDatabase
+        ).addMigrations(*allMigrations).build().apply {
+            openHelper.writableDatabase
+            close()
+        }
+    }
+}

--- a/app/src/main/java/fi/thl/koronahaavi/data/AppDatabase.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/AppDatabase.kt
@@ -10,7 +10,7 @@ import java.time.ZonedDateTime
 
 @Database(
     entities = [KeyGroupToken::class, Exposure::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/fi/thl/koronahaavi/data/DefaultExposureRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/DefaultExposureRepository.kt
@@ -1,7 +1,6 @@
 package fi.thl.koronahaavi.data
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import java.time.Duration
@@ -32,7 +31,7 @@ class DefaultExposureRepository (
     override suspend fun deleteExposure(id: Long) = exposureDao.delete(id)
 
     override suspend fun deleteExpiredExposuresAndTokens() {
-        val expireTime = getExpireTime()
+        val expireTime = getDetectionStart()
 
         getAllExposures().forEach {
             if (it.detectedDate.isBefore(expireTime)) {
@@ -49,44 +48,36 @@ class DefaultExposureRepository (
         }
     }
 
-    override fun flowAllExposures(): Flow<List<Exposure>> = exposureDao.flowAll()
+    override fun getIsExposedFlow(): Flow<Boolean> =
+        exposureDao.flowAll().map { exposures ->
+            val detectionStart = getDetectionStart()
 
-    override fun flowExposureNotifications(): Flow<List<ExposureNotification>> =
-        exposureDao.flowAll().map { all ->
-            // First filter out expired exposures, then group by created date, but because
-            // created date could theoretically be on a different second, group manually
-            // instead of using created date directly as a map key.
-
-            val result = mutableMapOf<ZonedDateTime, List<Exposure>>()
-            val expireTime = getExpireTime()
-
-            all.filter { e ->
-                e.detectedDate.isAfter(expireTime)
-            }.forEach { e ->
-                // find existing key that is close enough, or create new key
-                val key = result.keys.find {
-                    Duration.between(it, e.createdDate).abs().seconds < EXPOSURE_GROUPING_THRESHOLD_SECONDS
-                } ?: e.createdDate
-
-                // append to existing, or create a new entry
-                result[key] = result.getOrDefault(key, listOf()).plus(e)
+            exposures.any {
+                it.detectedDate.isAfter(detectionStart)
             }
-
-            result.map { ExposureNotification(it.key, it.value) }
         }
 
-    private fun getExpireTime(): ZonedDateTime {
+    override fun getExposureNotificationsFlow(): Flow<List<ExposureNotification>> =
+        keyGroupTokenDao.getAllMatchedFlow().map { groupTokens ->
+            val detectionStart = getDetectionStart()
+
+            groupTokens.filter {
+                it.latestExposureDate?.isAfter(detectionStart) == true
+            }.mapNotNull {
+                it.exposureCount?.let { count ->
+                    ExposureNotification(
+                        createdDate = it.updatedDate,
+                        exposureCount = count
+                    )
+                }
+            }
+        }
+
+    private fun getDetectionStart(): ZonedDateTime {
         // Exposure detection timestamp is rounded by EN to beginning of day in UTC, so in order to keep
         // exposure valid for configured number of days, we need to keep it a day longer from detection timestamp
         val validSinceDetectionDays = settingsRepository.appConfiguration.exposureValidDays + 1
 
         return ZonedDateTime.now().minusDays(validSinceDetectionDays.toLong())
-    }
-
-    companion object {
-        // Exposures created during same notification in earlier versions might have a very small difference
-        // in creation time, so we're allowing few seconds for that. Since v1.3 we use the same timestamp
-        // for all exposures within a notification, so this threshold is only for legacy support
-        const val EXPOSURE_GROUPING_THRESHOLD_SECONDS = 5
     }
 }

--- a/app/src/main/java/fi/thl/koronahaavi/data/DefaultExposureRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/DefaultExposureRepository.kt
@@ -15,7 +15,7 @@ class DefaultExposureRepository (
 
     override suspend fun saveKeyGroupToken(token: KeyGroupToken) = keyGroupTokenDao.insert(token)
 
-    override fun flowHandledKeyGroupTokens() = keyGroupTokenDao.flowHandled()
+    override fun flowHandledKeyGroupTokens() = keyGroupTokenDao.getHandledFlow()
 
     override suspend fun deleteKeyGroupToken(token: KeyGroupToken) = keyGroupTokenDao.delete(token)
 
@@ -60,7 +60,7 @@ class DefaultExposureRepository (
         }
 
     override fun getExposureNotificationsFlow(): Flow<List<ExposureNotification>> =
-        keyGroupTokenDao.getAllMatchedFlow().map { groupTokens ->
+        keyGroupTokenDao.getExposureTokensFlow().map { groupTokens ->
             val detectionStart = getDetectionStart()
 
             groupTokens.filter {

--- a/app/src/main/java/fi/thl/koronahaavi/data/ExposureNotification.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/ExposureNotification.kt
@@ -4,5 +4,5 @@ import java.time.ZonedDateTime
 
 data class ExposureNotification(
     val createdDate: ZonedDateTime,
-    val exposures: List<Exposure>
+    val exposureCount: Int
 )

--- a/app/src/main/java/fi/thl/koronahaavi/data/ExposureRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/ExposureRepository.kt
@@ -7,6 +7,7 @@ interface ExposureRepository {
     suspend fun saveKeyGroupToken(token: KeyGroupToken)
     fun flowHandledKeyGroupTokens(): Flow<List<KeyGroupToken>>
     suspend fun deleteKeyGroupToken(token: KeyGroupToken)
+    suspend fun deleteAllKeyGroupTokens()
     suspend fun saveExposure(exposure: Exposure)
     suspend fun getExposure(id: Long): Exposure?
     suspend fun getAllExposures(): List<Exposure>

--- a/app/src/main/java/fi/thl/koronahaavi/data/ExposureRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/ExposureRepository.kt
@@ -13,6 +13,6 @@ interface ExposureRepository {
     suspend fun deleteAllExposures()
     suspend fun deleteExpiredExposuresAndTokens()
     suspend fun deleteExposure(id: Long)
-    fun flowAllExposures(): Flow<List<Exposure>>
-    fun flowExposureNotifications(): Flow<List<ExposureNotification>>
+    fun getIsExposedFlow(): Flow<Boolean>
+    fun getExposureNotificationsFlow(): Flow<List<ExposureNotification>>
 }

--- a/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupToken.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupToken.kt
@@ -6,13 +6,19 @@ import androidx.room.PrimaryKey
 import java.time.ZonedDateTime
 
 /**
- * A string token that identifies a group of diagnosis keys, retrieved from backend server
- * and provided to exposure api using this string token as identifier
+ * Identifies a set of diagnosis keys retrieved from backend server, and the possible exposure
+ * notification shown to user based on that set of keys.
  */
 @Entity(tableName = "key_group_token")
 data class KeyGroupToken (
     @PrimaryKey val token: String,
     @ColumnInfo(name = "updated_date") val updatedDate: ZonedDateTime = ZonedDateTime.now(),
     @ColumnInfo(name = "matched_key_count") val matchedKeyCount: Int? = null,
-    @ColumnInfo(name = "maximum_risk_score") val maximumRiskScore: Int? = null
+    @ColumnInfo(name = "maximum_risk_score") val maximumRiskScore: Int? = null,
+
+    // Count of exposures
+    @ColumnInfo(name = "exposure_count") val exposureCount: Int? = null,
+
+    // Detection timestamp for the latest exposure in this group
+    @ColumnInfo(name = "latest_exposure_date") val latestExposureDate: ZonedDateTime? = null
 )

--- a/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupTokenDao.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupTokenDao.kt
@@ -13,10 +13,10 @@ interface KeyGroupTokenDao {
     suspend fun insert(token: KeyGroupToken)
 
     @Query("SELECT * FROM key_group_token WHERE matched_key_count NOT NULL ORDER BY updated_date ")
-    fun flowHandled(): Flow<List<KeyGroupToken>>
+    fun getHandledFlow(): Flow<List<KeyGroupToken>>
 
-    @Query("SELECT * FROM key_group_token WHERE matched_key_count > 0")
-    fun getAllMatchedFlow(): Flow<List<KeyGroupToken>>
+    @Query("SELECT * FROM key_group_token WHERE exposure_count > 0")
+    fun getExposureTokensFlow(): Flow<List<KeyGroupToken>>
 
     @Delete
     fun delete(vararg tokens: KeyGroupToken)

--- a/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupTokenDao.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupTokenDao.kt
@@ -20,4 +20,7 @@ interface KeyGroupTokenDao {
 
     @Delete
     fun delete(vararg tokens: KeyGroupToken)
+
+    @Query("DELETE FROM key_group_token")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupTokenDao.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/KeyGroupTokenDao.kt
@@ -15,6 +15,9 @@ interface KeyGroupTokenDao {
     @Query("SELECT * FROM key_group_token WHERE matched_key_count NOT NULL ORDER BY updated_date ")
     fun flowHandled(): Flow<List<KeyGroupToken>>
 
+    @Query("SELECT * FROM key_group_token WHERE matched_key_count > 0")
+    fun getAllMatchedFlow(): Flow<List<KeyGroupToken>>
+
     @Delete
     fun delete(vararg tokens: KeyGroupToken)
 }

--- a/app/src/main/java/fi/thl/koronahaavi/di/AppModule.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/di/AppModule.kt
@@ -73,13 +73,4 @@ object AppModule {
             .addConverterFactory(MoshiConverterFactory.create())
             .build()
     }
-
-    @Singleton
-    @Provides
-    fun provideExposureRepository(keyGroupTokenDao: KeyGroupTokenDao,
-                                  exposureDao: ExposureDao,
-                                  settingsRepository: SettingsRepository
-    ) : ExposureRepository {
-        return DefaultExposureRepository(keyGroupTokenDao, exposureDao, settingsRepository)
-    }
 }

--- a/app/src/main/java/fi/thl/koronahaavi/di/DatabaseModule.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/di/DatabaseModule.kt
@@ -9,8 +9,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ApplicationComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import fi.thl.koronahaavi.data.AppDatabase
-import fi.thl.koronahaavi.data.SettingsRepository
+import fi.thl.koronahaavi.data.*
 import net.sqlcipher.database.SupportFactory
 import timber.log.Timber
 import javax.inject.Singleton
@@ -38,6 +37,15 @@ object DatabaseModule {
     @Singleton
     @Provides
     fun provideExposureDao(database: AppDatabase) = database.exposureDao()
+
+    @Singleton
+    @Provides
+    fun provideExposureRepository(keyGroupTokenDao: KeyGroupTokenDao,
+                                  exposureDao: ExposureDao,
+                                  settingsRepository: SettingsRepository
+    ) : ExposureRepository {
+        return DefaultExposureRepository(keyGroupTokenDao, exposureDao, settingsRepository)
+    }
 
     // first app version 1.0 had schema version 3, so this is the first migration we need to address
     val migrationThreeToFour = object : Migration(3, 4) {

--- a/app/src/main/java/fi/thl/koronahaavi/di/DatabaseModule.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/di/DatabaseModule.kt
@@ -2,6 +2,8 @@ package fi.thl.koronahaavi.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,9 +25,9 @@ object DatabaseModule {
     ): AppDatabase {
 
         return Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, databaseName)
-            .fallbackToDestructiveMigration()
-            .openHelperFactory(SupportFactory(settingsRepository.getOrCreateDatabasePassword()))
-            .build()
+                .addMigrations(migrationThreeToFour)
+                .openHelperFactory(SupportFactory(settingsRepository.getOrCreateDatabasePassword()))
+                .build()
     }
 
     @Singleton
@@ -35,4 +37,12 @@ object DatabaseModule {
     @Singleton
     @Provides
     fun provideExposureDao(database: AppDatabase) = database.exposureDao()
+
+    // first app version 1.0 had schema version 3, so this is the first migration we need to address
+    private val migrationThreeToFour = object : Migration(3, 4) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("ALTER TABLE key_group_token ADD COLUMN exposure_count INTEGER")
+            database.execSQL("ALTER TABLE key_group_token ADD COLUMN latest_exposure_date INTEGER")
+        }
+    }
 }

--- a/app/src/main/java/fi/thl/koronahaavi/di/DatabaseModule.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/di/DatabaseModule.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import fi.thl.koronahaavi.data.AppDatabase
 import fi.thl.koronahaavi.data.SettingsRepository
 import net.sqlcipher.database.SupportFactory
+import timber.log.Timber
 import javax.inject.Singleton
 
 @Module
@@ -41,6 +42,7 @@ object DatabaseModule {
     // first app version 1.0 had schema version 3, so this is the first migration we need to address
     val migrationThreeToFour = object : Migration(3, 4) {
         override fun migrate(database: SupportSQLiteDatabase) {
+            Timber.d("Migrating from schema 3 to 4")
             database.execSQL("ALTER TABLE key_group_token ADD COLUMN exposure_count INTEGER")
             database.execSQL("ALTER TABLE key_group_token ADD COLUMN latest_exposure_date INTEGER")
         }

--- a/app/src/main/java/fi/thl/koronahaavi/di/DatabaseModule.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/di/DatabaseModule.kt
@@ -39,7 +39,7 @@ object DatabaseModule {
     fun provideExposureDao(database: AppDatabase) = database.exposureDao()
 
     // first app version 1.0 had schema version 3, so this is the first migration we need to address
-    private val migrationThreeToFour = object : Migration(3, 4) {
+    val migrationThreeToFour = object : Migration(3, 4) {
         override fun migrate(database: SupportSQLiteDatabase) {
             database.execSQL("ALTER TABLE key_group_token ADD COLUMN exposure_count INTEGER")
             database.execSQL("ALTER TABLE key_group_token ADD COLUMN latest_exposure_date INTEGER")

--- a/app/src/main/java/fi/thl/koronahaavi/exposure/ExposureDetailViewModel.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/exposure/ExposureDetailViewModel.kt
@@ -19,9 +19,10 @@ class ExposureDetailViewModel @ViewModelInject constructor(
     private val workDispatcher: WorkDispatcher,
     private val settingsRepository: SettingsRepository
 ) : ViewModel() {
-    private val exposureNotifications = exposureRepository.flowExposureNotifications().asLiveData()
-    val hasExposures = exposureNotifications.map { it.isNotEmpty() }
+    private val exposureNotifications = exposureRepository.getExposureNotificationsFlow().asLiveData()
+    val hasExposures = exposureRepository.getIsExposedFlow().asLiveData()
     val notificationCount = exposureNotifications.map { it.size }
+    val showNotifications = exposureNotifications.map { it.isNotEmpty() }
 
     val notifications = exposureNotifications.map {
         it.map(this::createNotificationData)
@@ -56,7 +57,7 @@ class ExposureDetailViewModel @ViewModelInject constructor(
             dateTime = notification.createdDate,
             exposureRangeStart = notification.createdDate.minusDays(rangeDays),
             exposureRangeEnd = notification.createdDate.minusDays(1),
-            exposureCount = notification.exposures.size
+            exposureCount = notification.exposureCount
         )
     }
 }

--- a/app/src/main/java/fi/thl/koronahaavi/home/HomeViewModel.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/home/HomeViewModel.kt
@@ -58,7 +58,9 @@ class HomeViewModel @ViewModelInject constructor(
     fun showManualCheck(): LiveData<Boolean> = showManualCheck.distinctUntilChanged()
     fun hideExposureSubLabel(): LiveData<Boolean> = exposureState.map { it is ExposureState.Clear.Disabled }
 
-    val notificationCount = exposureNotifications.map { it.size }
+    val notificationCount: LiveData<String?> = exposureNotifications.map {
+        if (it.isEmpty()) null else it.size.toString()
+    }
 
     val exposureCheckState: LiveData<Event<WorkState>> = newExposureCheckEvent.switchMap {
         workDispatcher.runUpdateWorker()

--- a/app/src/main/java/fi/thl/koronahaavi/home/HomeViewModel.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/home/HomeViewModel.kt
@@ -42,8 +42,8 @@ class HomeViewModel @ViewModelInject constructor(
 
     val checkInProgress = MutableLiveData<Boolean>(false)
 
-    private val exposureNotifications = exposureRepository.flowExposureNotifications().asLiveData()
-    val hasExposures = exposureNotifications.map { it.isNotEmpty() }
+    private val exposureNotifications = exposureRepository.getExposureNotificationsFlow().asLiveData()
+    val hasExposures = exposureRepository.getIsExposedFlow().asLiveData()
     private val lastCheckTime = appStateRepository.getLastExposureCheckTimeLive()
     private val isENEnabled = exposureNotificationService.isEnabledFlow().asLiveData()
     private val isBluetoothOn = deviceStateRepository.bluetoothOn()

--- a/app/src/main/java/fi/thl/koronahaavi/service/FakeExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/FakeExposureNotificationService.kt
@@ -65,19 +65,19 @@ class FakeExposureNotificationService(
 
     override suspend fun getExposureSummary(token: String): ExposureSummary {
         return ExposureSummary.ExposureSummaryBuilder()
-            .setMatchedKeyCount(1)
+            .setMatchedKeyCount(Random.nextInt(1,4))
             .setMaximumRiskScore(200)
             .build()
     }
 
     override suspend fun getExposureDetails(token: String): List<Exposure> {
-        return listOf(
+        return List(Random.nextInt(1,3)) {
             Exposure(
-                detectedDate = ZonedDateTime.now().minusDays(2),
+                detectedDate = ZonedDateTime.now().minusDays(Random.nextLong(2,6)),
                 totalRiskScore = 200,
                 createdDate = ZonedDateTime.now()
             )
-        )
+        }
     }
 
     override suspend fun provideDiagnosisKeyFiles(token: String, files: List<File>, config: ExposureConfigurationData)

--- a/app/src/main/java/fi/thl/koronahaavi/test/TestFragment.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/test/TestFragment.kt
@@ -167,11 +167,6 @@ class TestFragment : Fragment() {
             }
         }
 
-        exposureRepository.flowAllExposures().asLiveData().observe(viewLifecycleOwner, Observer {
-            val scores = it.joinToString { e -> e.totalRiskScore.toString() }
-            binding.testExposureRiskScores.text = "Exposure risk scores: $scores"
-        })
-
         exposureRepository.flowHandledKeyGroupTokens().asLiveData().observe(viewLifecycleOwner, Observer {
             val tokens = it.joinToString { t -> "(${t.matchedKeyCount},${t.maximumRiskScore})" }
             binding.testExposureRiskScores.text = "Updated tokens: $tokens"

--- a/app/src/main/java/fi/thl/koronahaavi/test/TestFragment.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/test/TestFragment.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import timber.log.Timber
 import java.time.ZonedDateTime
+import java.util.*
 import javax.inject.Inject
 
 @SuppressLint("SetTextI18n")
@@ -73,6 +74,7 @@ class TestFragment : Fragment() {
         binding.buttonTestClearExposures.setOnClickListener {
             requireActivity().lifecycleScope.launch {
                 exposureRepository.deleteAllExposures()
+                exposureRepository.deleteAllKeyGroupTokens()
             }
         }
 
@@ -182,7 +184,7 @@ class TestFragment : Fragment() {
             val intent = Intent().apply {
                 component = ComponentName(requireContext(), ExposureStateUpdatedReceiver::class.java)
                 action = ExposureNotificationClient.ACTION_EXPOSURE_STATE_UPDATED
-                putExtra(ExposureNotificationClient.EXTRA_TOKEN, "123")
+                putExtra(ExposureNotificationClient.EXTRA_TOKEN, UUID.randomUUID().toString())
             }
             requireContext().sendBroadcast(intent)
         }

--- a/app/src/main/res/layout/fragment_exposure_detail.xml
+++ b/app/src/main/res/layout/fragment_exposure_detail.xml
@@ -213,6 +213,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     layout="@layout/link_item_card"
+                    android:visibility="@{model.showNotifications ? View.VISIBLE : View.GONE}"
                     app:label="@{@string/exposure_detail_notifications_title}"
                     app:link="@{@plurals/exposure_notification_count(model.notificationCount ?? 0, model.notificationCount ?? 0)}"
                     app:noLinkColor="@{true}"

--- a/app/src/main/res/layout/fragment_exposure_detail.xml
+++ b/app/src/main/res/layout/fragment_exposure_detail.xml
@@ -182,7 +182,7 @@
                             android:layout_height="wrap_content"
                             android:hyphenationFrequency="normal"
                             android:text="@string/exposure_detail_contact_title"
-                            android:textAppearance="?attr/textAppearanceHeadline2" />
+                            android:textAppearance="?attr/textAppearanceHeadline3" />
 
                         <TextView
                             android:id="@+id/text_exposure_detail_contact_subtitle"
@@ -198,7 +198,7 @@
                             android:layout_height="wrap_content"
                             android:text="@string/exposure_detail_contact_start"
                             android:visibility="@{model.hasExposures ? View.VISIBLE : View.GONE}"
-                            tools:visibility="gone"/>
+                            tools:visibility="visible"/>
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
                 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -167,11 +167,11 @@
                             app:layout_constraintTop_toTopOf="@id/layout_home_exposure_labels"
                             app:layout_constraintEnd_toStartOf="@+id/image_home_exposure_status"
                             android:layout_marginEnd="8dp"
-                            android:text="@{model.notificationCount.toString()}"
+                            android:text="@{model.notificationCount > 0 ? model.notificationCount.toString() : @string/home_notifications_unknown}"
                             android:visibility="@{model.hasExposures==true ? View.VISIBLE : View.GONE}"
                             style="@style/Widget.Vilkku.TextView.Badge"
                             android:backgroundTint="?attr/colorError"
-                            tools:text="16"
+                            tools:text="@string/home_notifications_unknown"
                             tools:visibility="visible"/>
 
                         <!-- visibility updated in code only if needed to prevent icon background flicker -->

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -167,7 +167,7 @@
                             app:layout_constraintTop_toTopOf="@id/layout_home_exposure_labels"
                             app:layout_constraintEnd_toStartOf="@+id/image_home_exposure_status"
                             android:layout_marginEnd="8dp"
-                            android:text="@{model.notificationCount > 0 ? model.notificationCount.toString() : @string/home_notifications_unknown}"
+                            android:text="@{model.notificationCount ?? @string/home_notifications_unknown}"
                             android:visibility="@{model.hasExposures==true ? View.VISIBLE : View.GONE}"
                             style="@style/Widget.Vilkku.TextView.Badge"
                             android:backgroundTint="?attr/colorError"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="home_no_exposure_sub_label">You have not been near a person who has reported an infection</string>
     <string name="home_exposure_instructions">See instructions</string>
     <string name="home_exposure_check">Check now</string>
+    <string name="home_notifications_unknown" translatable="false">!</string>
 
     <string name="home_symptom_label">Do you think you may have COVID-19?</string>
     <string name="home_prevention_label">Protect yourself</string>

--- a/app/src/test/java/fi/thl/koronahaavi/data/DefaultExposureRepositoryTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/data/DefaultExposureRepositoryTest.kt
@@ -46,7 +46,7 @@ class DefaultExposureRepositoryTest {
         ))
 
         runBlocking {
-            repository.flowExposureNotifications().collectLatest {
+            repository.getExposureNotificationsFlow().collectLatest {
                 assertEquals(3, it.size)
                 assertTrue(it.any { n -> n.createdDate == baseCreatedDate.minus(Duration.ofDays(2)) })
                 assertTrue(it.any { n -> n.createdDate == baseCreatedDate.minus(Duration.ofDays(3)) })

--- a/app/src/test/java/fi/thl/koronahaavi/data/DefaultExposureRepositoryTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/data/DefaultExposureRepositoryTest.kt
@@ -78,7 +78,7 @@ class DefaultExposureRepositoryTest {
 
     @Test
     fun notificationsEmptyWithNoData() {
-        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf())
+        every { keyGroupTokenDao.getExposureTokensFlow() } returns flowOf(listOf())
 
         runBlocking {
             repository.getExposureNotificationsFlow().collectLatest {
@@ -89,7 +89,7 @@ class DefaultExposureRepositoryTest {
 
     @Test
     fun notificationsEmptyWithLegacyData() {
-        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf(
+        every { keyGroupTokenDao.getExposureTokensFlow() } returns flowOf(listOf(
             createLegacyKeyGroupToken()
         ))
 
@@ -102,7 +102,7 @@ class DefaultExposureRepositoryTest {
 
     @Test
     fun notificationsWithLegacyData() {
-        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf(
+        every { keyGroupTokenDao.getExposureTokensFlow() } returns flowOf(listOf(
             createLegacyKeyGroupToken(),
             createKeyGroupToken(),
             createKeyGroupToken()
@@ -117,7 +117,7 @@ class DefaultExposureRepositoryTest {
 
     @Test
     fun notificationsEmptyWithMissingCount() {
-        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf(
+        every { keyGroupTokenDao.getExposureTokensFlow() } returns flowOf(listOf(
             createKeyGroupToken().copy(exposureCount = null)
         ))
 
@@ -132,7 +132,7 @@ class DefaultExposureRepositoryTest {
     fun notificationsWithOldData() {
         val limitDays = TestData.appConfig.exposureValidDays + 1L
 
-        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf(
+        every { keyGroupTokenDao.getExposureTokensFlow() } returns flowOf(listOf(
             createKeyGroupToken().copy(latestExposureDate = ZonedDateTime.now().minusDays(limitDays + 1L)),
             createKeyGroupToken().copy(latestExposureDate = ZonedDateTime.now().minusDays(limitDays - 1L)),
             createKeyGroupToken()

--- a/app/src/test/java/fi/thl/koronahaavi/data/DefaultExposureRepositoryTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/data/DefaultExposureRepositoryTest.kt
@@ -8,14 +8,14 @@ import io.mockk.mockk
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import java.time.Duration
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.TemporalAmount
+import java.util.*
 
 class DefaultExposureRepositoryTest {
     private lateinit var repository: DefaultExposureRepository
@@ -35,22 +35,112 @@ class DefaultExposureRepositoryTest {
     }
 
     @Test
-    fun flowExposureNotifications() {
+    fun clearWhenNoExposures() {
+        every { exposureDao.flowAll() } returns flowOf(listOf())
+
+        runBlocking {
+            repository.getIsExposedFlow().collectLatest {
+                assertFalse(it)
+            }
+        }
+    }
+
+    @Test
+    fun clearWhenExposuresOld() {
+        val limitDays = TestData.appConfig.exposureValidDays + 1L
+
         every { exposureDao.flowAll() } returns flowOf(listOf(
-            createExposure(Duration.ofDays(2)),
-            createExposure(Duration.ofDays(2).plusSeconds(1)),
-            createExposure(Duration.ofDays(2).minusSeconds(1)),
-            createExposure(Duration.ofDays(3)),
-            createExposure(Duration.ofDays(3)),
-            createExposure(Duration.ofDays(4))
+            createExposure().copy(detectedDate = ZonedDateTime.now().minusDays(limitDays + 1L)),
+            createExposure().copy(detectedDate = ZonedDateTime.now().minusDays(limitDays + 2L))
+        ))
+
+        runBlocking {
+            repository.getIsExposedFlow().collectLatest {
+                assertFalse(it)
+            }
+        }
+    }
+
+    @Test
+    fun isExposed() {
+        every { exposureDao.flowAll() } returns flowOf(listOf(
+            createExposure().copy(
+                detectedDate = ZonedDateTime.now().minusDays(TestData.appConfig.exposureValidDays.toLong())
+            )
+        ))
+
+        runBlocking {
+            repository.getIsExposedFlow().collectLatest {
+                assertTrue(it)
+            }
+        }
+    }
+
+    @Test
+    fun notificationsEmptyWithNoData() {
+        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf())
+
+        runBlocking {
+            repository.getExposureNotificationsFlow().collectLatest {
+                assertTrue(it.isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun notificationsEmptyWithLegacyData() {
+        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf(
+            createLegacyKeyGroupToken()
         ))
 
         runBlocking {
             repository.getExposureNotificationsFlow().collectLatest {
-                assertEquals(3, it.size)
-                assertTrue(it.any { n -> n.createdDate == baseCreatedDate.minus(Duration.ofDays(2)) })
-                assertTrue(it.any { n -> n.createdDate == baseCreatedDate.minus(Duration.ofDays(3)) })
-                assertTrue(it.any { n -> n.createdDate == baseCreatedDate.minus(Duration.ofDays(4)) })
+                assertTrue(it.isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun notificationsWithLegacyData() {
+        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf(
+            createLegacyKeyGroupToken(),
+            createKeyGroupToken(),
+            createKeyGroupToken()
+        ))
+
+        runBlocking {
+            repository.getExposureNotificationsFlow().collectLatest {
+                assertEquals(2, it.size)
+            }
+        }
+    }
+
+    @Test
+    fun notificationsEmptyWithMissingCount() {
+        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf(
+            createKeyGroupToken().copy(exposureCount = null)
+        ))
+
+        runBlocking {
+            repository.getExposureNotificationsFlow().collectLatest {
+                assertTrue(it.isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun notificationsWithOldData() {
+        val limitDays = TestData.appConfig.exposureValidDays + 1L
+
+        every { keyGroupTokenDao.getAllMatchedFlow() } returns flowOf(listOf(
+            createKeyGroupToken().copy(latestExposureDate = ZonedDateTime.now().minusDays(limitDays + 1L)),
+            createKeyGroupToken().copy(latestExposureDate = ZonedDateTime.now().minusDays(limitDays - 1L)),
+            createKeyGroupToken()
+        ))
+
+        runBlocking {
+            repository.getExposureNotificationsFlow().collectLatest {
+                assertEquals(2, it.size)
             }
         }
     }
@@ -84,12 +174,17 @@ class DefaultExposureRepositoryTest {
 
         coEvery { exposureDao.getAll() } returns listOf()
 
+        // legacy
         val tokenA = KeyGroupToken("a", now.minusDays(ttlDays - 10L))
         val tokenB = KeyGroupToken("b", now.minusDays(ttlDays - 1L))
         val tokenC = KeyGroupToken("c", now.minusDays(15).minusHours(1))
 
+        // updated with exposure date
+        val tokenD = createKeyGroupToken().copy(latestExposureDate = now.minusDays(ttlDays + 1L))
+        val tokenE = createKeyGroupToken().copy(latestExposureDate = now.minusDays(ttlDays - 1L))
+
         coEvery { keyGroupTokenDao.getAll() } returns
-                listOf(tokenA, tokenB, tokenC)
+                listOf(tokenA, tokenB, tokenC, tokenD, tokenE)
 
         runBlocking {
             repository.deleteExpiredExposuresAndTokens()
@@ -97,11 +192,26 @@ class DefaultExposureRepositoryTest {
             coVerify(exactly = 0) { keyGroupTokenDao.delete(tokenA) }
             coVerify(exactly = 0) { keyGroupTokenDao.delete(tokenB) }
             coVerify(exactly = 1) { keyGroupTokenDao.delete(tokenC) }
+            coVerify(exactly = 1) { keyGroupTokenDao.delete(tokenD) }
+            coVerify(exactly = 0) { keyGroupTokenDao.delete(tokenE) }
         }
     }
 
     private val baseCreatedDate = ZonedDateTime.of(2020, 1, 1, 1, 1, 1, 0, ZoneId.of("Z"))
 
-    private fun createExposure(age: TemporalAmount)
+    private fun createExposure(age: TemporalAmount = Duration.ofDays(1))
             = Exposure(1, ZonedDateTime.now(), baseCreatedDate.minus(age), 0)
+
+    private fun createKeyGroupToken() =
+        KeyGroupToken(
+            token = UUID.randomUUID().toString(),
+            updatedDate = ZonedDateTime.now(),
+            matchedKeyCount = 1,
+            maximumRiskScore = 100,
+            exposureCount = 1,
+            latestExposureDate = ZonedDateTime.now().minusDays(2)
+        )
+
+    private fun createLegacyKeyGroupToken() =
+        createKeyGroupToken().copy(exposureCount = null, latestExposureDate = null)
 }

--- a/app/src/test/java/fi/thl/koronahaavi/exposure/ExposureDetailViewModelTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/exposure/ExposureDetailViewModelTest.kt
@@ -39,12 +39,11 @@ class ExposureDetailViewModelTest {
 
         every { settingsRepository.appConfiguration } returns TestData.appConfig
 
-        every { exposureRepository.flowExposureNotifications() } returns flowOf(listOf(
-            ExposureNotification(notificationCreatedDate, listOf(
-                TestData.exposure(),
-                TestData.exposure()
-            ))
+        every { exposureRepository.getExposureNotificationsFlow() } returns flowOf(listOf(
+            ExposureNotification(notificationCreatedDate, 2)
         ))
+
+        every { exposureRepository.getIsExposedFlow() } returns flowOf(true)
 
         viewModel = ExposureDetailViewModel(
             exposureRepository, appStateRepository, exposureNotificationService, workDispatcher, settingsRepository

--- a/app/src/test/java/fi/thl/koronahaavi/home/HomeViewModelTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/home/HomeViewModelTest.kt
@@ -2,7 +2,6 @@ package fi.thl.koronahaavi.home
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
-import com.google.android.gms.common.internal.constants.ListAppsActivityContract
 import com.jraska.livedata.test
 import fi.thl.koronahaavi.common.Event
 import fi.thl.koronahaavi.data.AppStateRepository
@@ -17,7 +16,6 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -52,7 +50,8 @@ class HomeViewModelTest {
         every { deviceStateRepository.bluetoothOn() } returns bluetoothOn
         every { deviceStateRepository.locationOn() } returns locationOn
         every { exposureNotificationService.isEnabledFlow() } returns enEnabledFlow
-        every { exposureRepository.flowExposureNotifications() } returns flowOf(listOf())
+        every { exposureRepository.getExposureNotificationsFlow() } returns flowOf(listOf())
+        every { exposureRepository.getIsExposedFlow() } returns flowOf(false)
         every { appStateRepository.getLastExposureCheckTimeLive() } returns lastCheckTime
 
         viewModel = HomeViewModel(exposureRepository, deviceStateRepository, appStateRepository, exposureNotificationService, workDispatcher)

--- a/app/src/test/java/fi/thl/koronahaavi/home/HomeViewModelTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/home/HomeViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.jraska.livedata.test
 import fi.thl.koronahaavi.common.Event
 import fi.thl.koronahaavi.data.AppStateRepository
+import fi.thl.koronahaavi.data.ExposureNotification
 import fi.thl.koronahaavi.data.ExposureRepository
 import fi.thl.koronahaavi.device.DeviceStateRepository
 import fi.thl.koronahaavi.device.SystemState
@@ -54,7 +55,7 @@ class HomeViewModelTest {
         every { exposureRepository.getIsExposedFlow() } returns flowOf(false)
         every { appStateRepository.getLastExposureCheckTimeLive() } returns lastCheckTime
 
-        viewModel = HomeViewModel(exposureRepository, deviceStateRepository, appStateRepository, exposureNotificationService, workDispatcher)
+        viewModel = createViewModel()
     }
 
     @Test
@@ -120,6 +121,24 @@ class HomeViewModelTest {
 
         viewModel.hideExposureSubLabel().test().assertValue(true)
     }
+
+    @Test
+    fun notificationCountNotAvailable() {
+        viewModel.notificationCount.test().assertNullValue()
+    }
+
+    @Test
+    fun notificationCountAvailable() {
+        every { exposureRepository.getExposureNotificationsFlow() } returns flowOf(listOf(
+            ExposureNotification(ZonedDateTime.now(), 2)
+        ))
+        viewModel = createViewModel()
+
+        viewModel.notificationCount.test().assertValue { it == "1"}
+    }
+
+    private fun createViewModel() =
+        HomeViewModel(exposureRepository, deviceStateRepository, appStateRepository, exposureNotificationService, workDispatcher)
 
     private fun setSystemOn() {
         enEnabledFlow.value = true


### PR DESCRIPTION
* Add fields to key group token to support exposure notification list item
* Modify DAO and repository layer to use key group token
* Modify home and exposure detail view model and fragment data binding to use new repository methods
* Refactor DI structure to support testing