### PR TITLE
Add EU interoperability data to backend api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -225,6 +225,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinXVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinXVersion"
     testImplementation 'com.jraska.livedata:testing-ktx:1.1.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
 
     // Android test
     debugImplementation 'androidx.fragment:fragment-testing:1.2.5'

--- a/app/src/main/java/fi/thl/koronahaavi/data/SettingsRepository.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/data/SettingsRepository.kt
@@ -33,6 +33,8 @@ class SettingsRepository @Inject constructor (
         appConfiguration = defaultAppConfig
     }
 
+    fun getExposureConfiguration(): ExposureConfigurationData? = exposureConfiguration
+
     fun requireExposureConfiguration() : ExposureConfigurationData =
         exposureConfiguration ?:
         loadExposureConfig() ?:

--- a/app/src/main/java/fi/thl/koronahaavi/diagnosis/CodeEntryViewModel.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/diagnosis/CodeEntryViewModel.kt
@@ -17,7 +17,7 @@ class CodeEntryViewModel @ViewModelInject constructor(
     private val diagnosisKeyService: DiagnosisKeyService,
     private val appStateRepository: AppStateRepository,
     private val workDispatcher: WorkDispatcher,
-    settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     val code = MutableLiveData<String>()
@@ -102,7 +102,17 @@ class CodeEntryViewModel @ViewModelInject constructor(
     }
 
     private suspend fun sendKeys(authCode: String, keys: List<TemporaryExposureKey>) {
-        when (diagnosisKeyService.sendExposureKeys(authCode, keys)) {
+        // todo replace with actual UI selections
+        val selectedCountries = settingsRepository.getExposureConfiguration()?.participatingCountries?.take(2)
+            ?: listOf()
+        val consentToShare = true
+
+        when (diagnosisKeyService.sendExposureKeys(
+            authCode = authCode,
+            keyHistory = keys,
+            visitedCountryCodes = selectedCountries,
+            consentToShare = consentToShare
+        )) {
             is SendKeysResult.Success -> {
                 // stop observing locked state since we are about to lock the app, and error
                 // might have time to show in UI before navigating away

--- a/app/src/main/java/fi/thl/koronahaavi/service/DiagnosisKeySendTrafficCoverWorker.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/DiagnosisKeySendTrafficCoverWorker.kt
@@ -25,6 +25,8 @@ class DiagnosisKeySendTrafficCoverWorker @WorkerInject constructor(
             diagnosisKeyService.sendExposureKeys(
                 authCode = DiagnosisKeyService.FAKE_TOKEN,
                 keyHistory = listOf(),
+                visitedCountryCodes = listOf(),
+                consentToShare = true,
                 isFake = true
             )
         }

--- a/app/src/main/java/fi/thl/koronahaavi/service/FakeBackendService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/FakeBackendService.kt
@@ -7,7 +7,7 @@ import timber.log.Timber
 // not used at the moment, but maybe for standalone demo build or testing
 class FakeBackendService : BackendService {
 
-    override suspend fun sendKeys(token: String, data: DiagnosisKeyList, type: BackendService.RequestType) {
+    override suspend fun sendKeys(token: String, data: DiagnosisKeyList, isFake: BackendService.NumericBoolean) {
         Timber.d("Sending keys")
     }
 
@@ -29,7 +29,8 @@ class FakeBackendService : BackendService {
             transmissionRiskScoresAndroid = listOf(),
             durationAtAttenuationThresholds = listOf(),
             durationAtAttenuationWeights = listOf(1.0f, 0.5f, 0.0f),
-            exposureRiskDuration = 15
+            exposureRiskDuration = 15,
+            participatingCountries = listOf("DK", "DE", "IE", "IT", "LV", "ES")
         )
     }
 

--- a/app/src/test/java/fi/thl/koronahaavi/diagnosis/CodeEntryViewModelTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/diagnosis/CodeEntryViewModelTest.kt
@@ -48,7 +48,7 @@ class CodeEntryViewModelTest {
 
         coEvery { exposureNotificationService.isEnabledFlow() } returns enEnabledFlow
         coEvery { exposureNotificationService.getTemporaryExposureKeys() } returns Success(listOf())
-        coEvery { diagnosisKeyService.sendExposureKeys(any(), any()) } returns SendKeysResult.Success
+        coEvery { diagnosisKeyService.sendExposureKeys(any(), any(), any(), any()) } returns SendKeysResult.Success
 
         viewModel = CodeEntryViewModel(exposureNotificationService, diagnosisKeyService, appStateRepository, workDispatcher, settingsRepository)
     }
@@ -83,7 +83,7 @@ class CodeEntryViewModelTest {
             viewModel.submit()
 
             viewModel.keyHistoryResolutionEvent().test().assertHasValue()
-            coVerify(exactly = 0) { diagnosisKeyService.sendExposureKeys(any(), any()) }
+            coVerify(exactly = 0) { diagnosisKeyService.sendExposureKeys(any(), any(), any(), any()) }
         }
     }
 
@@ -93,7 +93,7 @@ class CodeEntryViewModelTest {
             viewModel.code.postValue("1234")
             viewModel.submit()
 
-            coVerify { diagnosisKeyService.sendExposureKeys(any(), any()) }
+            coVerify { diagnosisKeyService.sendExposureKeys(any(), any(), any(), any()) }
             coVerify { appStateRepository.setDiagnosisKeysSubmitted(true) }
         }
     }

--- a/app/src/test/java/fi/thl/koronahaavi/exposure/ExposureSummaryCheckerTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/exposure/ExposureSummaryCheckerTest.kt
@@ -1,10 +1,9 @@
 @file:Suppress("DEPRECATION")
 package fi.thl.koronahaavi.exposure
 
-import com.google.android.gms.nearby.exposurenotification.ExposureInformation.ExposureInformationBuilder
 import com.google.android.gms.nearby.exposurenotification.ExposureSummary
 import fi.thl.koronahaavi.data.Exposure
-import fi.thl.koronahaavi.service.ExposureConfigurationData
+import fi.thl.koronahaavi.utils.TestData
 import org.junit.Assert.*
 import org.junit.Test
 import java.time.*
@@ -15,7 +14,7 @@ class ExposureSummaryCheckerTest {
     fun noRisk() {
         val checker = ExposureSummaryChecker(
             summary().setMaximumRiskScore(0).setAttenuationDurations(intArrayOf(0,0,0)).build(),
-            configuration
+            TestData.exposureConfiguration()
         )
         assertFalse(checker.hasHighRisk())
     }
@@ -24,7 +23,7 @@ class ExposureSummaryCheckerTest {
     fun lowRisk() {
         val checker = ExposureSummaryChecker(
             summary().setMaximumRiskScore(10).setAttenuationDurations(intArrayOf(9,11,10)).build(),
-            configuration
+            TestData.exposureConfiguration()
         )
         assertFalse(checker.hasHighRisk())
     }
@@ -33,7 +32,7 @@ class ExposureSummaryCheckerTest {
     fun highRiskScore() {
         val checker = ExposureSummaryChecker(
             summary().setMaximumRiskScore(200).build(),
-            configuration
+            TestData.exposureConfiguration()
         )
         assertTrue(checker.hasHighRisk())
     }
@@ -42,7 +41,7 @@ class ExposureSummaryCheckerTest {
     fun longDurationFirst() {
         val checker = ExposureSummaryChecker(
             summary().setMaximumRiskScore(10).setAttenuationDurations(intArrayOf(30,0,0)).build(),
-            configuration
+            TestData.exposureConfiguration()
         )
         assertTrue(checker.hasHighRisk())
     }
@@ -51,7 +50,7 @@ class ExposureSummaryCheckerTest {
     fun longDurationSecond() {
         val checker = ExposureSummaryChecker(
             summary().setMaximumRiskScore(10).setAttenuationDurations(intArrayOf(0,30,0)).build(),
-            configuration
+            TestData.exposureConfiguration()
         )
         assertTrue(checker.hasHighRisk())
     }
@@ -60,7 +59,7 @@ class ExposureSummaryCheckerTest {
     fun longDurationThreshold() {
         val checker = ExposureSummaryChecker(
             summary().setMaximumRiskScore(10).setAttenuationDurations(intArrayOf(10,10,0)).build(),
-            configuration
+            TestData.exposureConfiguration()
         )
         assertTrue(checker.hasHighRisk())
     }
@@ -69,7 +68,7 @@ class ExposureSummaryCheckerTest {
     fun unexpectedWeightArray() {
         val checker = ExposureSummaryChecker(
             summary().build(),
-            configuration.copy(durationAtAttenuationWeights = listOf(1.0f))
+            TestData.exposureConfiguration().copy(durationAtAttenuationWeights = listOf(1.0f))
         )
         assertTrue(checker.hasHighRisk())
     }
@@ -78,7 +77,7 @@ class ExposureSummaryCheckerTest {
     fun selectsLatestForDuration() {
         val checker = ExposureSummaryChecker(
             summary().setMaximumRiskScore(10).setAttenuationDurations(intArrayOf(30,30,0)).build(),
-            configuration
+            TestData.exposureConfiguration()
         )
 
         val created = ZonedDateTime.now()
@@ -98,17 +97,4 @@ class ExposureSummaryCheckerTest {
         .setMatchedKeyCount(1)
         .setMaximumRiskScore(200)
         .setAttenuationDurations(intArrayOf(20,10,0))
-
-
-    private val configuration = ExposureConfigurationData(
-        version = 1,
-        minimumRiskScore = 100,
-        attenuationScores = listOf(),
-        daysSinceLastExposureScores = listOf(),
-        durationScores = listOf(),
-        transmissionRiskScoresAndroid = listOf(),
-        durationAtAttenuationThresholds = listOf(),
-        durationAtAttenuationWeights = listOf(1.0f, 0.5f, 0.0f),
-        exposureRiskDuration = 15
-    )
 }

--- a/app/src/test/java/fi/thl/koronahaavi/exposure/ExposureUpdateWorkerTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/exposure/ExposureUpdateWorkerTest.kt
@@ -17,7 +17,6 @@ import fi.thl.koronahaavi.data.AppStateRepository
 import fi.thl.koronahaavi.data.ExposureRepository
 import fi.thl.koronahaavi.data.KeyGroupToken
 import fi.thl.koronahaavi.data.SettingsRepository
-import fi.thl.koronahaavi.service.ExposureConfigurationData
 import fi.thl.koronahaavi.service.ExposureNotificationService
 import fi.thl.koronahaavi.utils.TestData
 import io.mockk.*
@@ -54,7 +53,7 @@ class ExposureUpdateWorkerTest {
         settingsRepository = mockk(relaxed = true)
 
         every { appStateRepository.lockedAfterDiagnosis() } returns lockedFlow
-        every { settingsRepository.requireExposureConfiguration() } returns configuration
+        every { settingsRepository.requireExposureConfiguration() } returns TestData.exposureConfiguration()
         coEvery { exposureNotificationService.isEnabled() } returns true
 
         worker = TestListenableWorkerBuilder<ExposureUpdateWorker>(context)
@@ -169,16 +168,4 @@ class ExposureUpdateWorkerTest {
                 exposureRepository, appStateRepository, settingsRepository)
         }
     }
-
-    private val configuration = ExposureConfigurationData(
-        version = 1,
-        minimumRiskScore = 100,
-        attenuationScores = listOf(),
-        daysSinceLastExposureScores = listOf(),
-        durationScores = listOf(),
-        transmissionRiskScoresAndroid = listOf(),
-        durationAtAttenuationThresholds = listOf(),
-        durationAtAttenuationWeights = listOf(1.0f, 0.5f, 0.0f),
-        exposureRiskDuration = 15
-    )
 }

--- a/app/src/test/java/fi/thl/koronahaavi/service/BackendServiceTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/service/BackendServiceTest.kt
@@ -1,0 +1,69 @@
+package fi.thl.koronahaavi.service
+
+import fi.thl.koronahaavi.di.AppModule
+import fi.thl.koronahaavi.di.NetworkModule
+import fi.thl.koronahaavi.service.BackendService.NumericBoolean
+import fi.thl.koronahaavi.utils.TestData
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class BackendServiceTest {
+    private lateinit var mockServer: MockWebServer
+    private lateinit var backendService: BackendService
+
+    @Before
+    fun setup() {
+        mockServer = MockWebServer()
+        mockServer.start()
+
+        // creating instance through DI modules to verify their setup
+        val httpClient = AppModule.provideHttpClient()
+        val retrofit = AppModule.provideRetrofit(httpClient, mockServer.url("/").toString())
+        backendService = NetworkModule.provideBackendService(retrofit)
+    }
+
+    @After
+    fun teardown() {
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun testSendKeys() {
+        val payload = DiagnosisKeyList(
+                keys = listOf(
+                        TestData.diagnosisKey(),
+                        TestData.diagnosisKey()
+                ),
+                visitedCountries = mapOf(
+                        "aa" to NumericBoolean.FALSE,
+                        "bb" to NumericBoolean.FALSE,
+                        "cc" to NumericBoolean.TRUE
+                ),
+                consentToShareWithEfgs = NumericBoolean.FALSE
+        )
+
+        mockServer.enqueue(MockResponse())
+
+        runBlocking {
+            backendService.sendKeys(
+                    token = "test_token",
+                    data = payload,
+                    isFake = NumericBoolean.FALSE
+            )
+
+            val req = mockServer.takeRequest()
+            val body = req.body.readUtf8()
+
+            assertTrue(body.contains("\"consentToShareWithEfgs\":0"))
+            assertTrue(body.contains("\"aa\":0,\"bb\":0,\"cc\":1"))
+            assertEquals("0", req.getHeader("KV-Fake-Request"))
+            assertEquals("test_token", req.getHeader("KV-Publish-Token"))
+        }
+    }
+}

--- a/app/src/test/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorkerTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorkerTest.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
 import fi.thl.koronahaavi.data.AppStateRepository
 import fi.thl.koronahaavi.data.ExposureRepository
+import fi.thl.koronahaavi.utils.TestData
 import io.mockk.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
@@ -187,15 +188,5 @@ class DiagnosisKeyUpdateWorkerTest {
         }
     }
 
-    private val exposureConfig = ExposureConfigurationData(
-        version = 1,
-        minimumRiskScore = 0,
-        attenuationScores = listOf(),
-        daysSinceLastExposureScores = listOf(),
-        durationScores = listOf(),
-        transmissionRiskScoresAndroid = listOf(),
-        durationAtAttenuationThresholds = listOf(),
-        durationAtAttenuationWeights = listOf(1.0f, 0.5f, 0.0f),
-        exposureRiskDuration = 15
-    )
+    private val exposureConfig = TestData.exposureConfiguration()
 }

--- a/app/src/test/java/fi/thl/koronahaavi/utils/TestData.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/utils/TestData.kt
@@ -5,6 +5,8 @@ import fi.thl.koronahaavi.data.OmaoloFeatures
 import fi.thl.koronahaavi.data.ServiceLanguages
 import fi.thl.koronahaavi.exposure.Municipality
 import fi.thl.koronahaavi.service.AppConfiguration
+import fi.thl.koronahaavi.service.DiagnosisKey
+import fi.thl.koronahaavi.service.ExposureConfigurationData
 import java.time.Duration
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -41,5 +43,25 @@ object TestData {
         available = true,
         serviceLanguages = ServiceLanguages(fi = true, sv = true, en = null),
         symptomAssessmentOnly = null
+    )
+
+    fun exposureConfiguration() = ExposureConfigurationData(
+        version = 1,
+        minimumRiskScore = 100,
+        attenuationScores = listOf(),
+        daysSinceLastExposureScores = listOf(),
+        durationScores = listOf(),
+        transmissionRiskScoresAndroid = listOf(),
+        durationAtAttenuationThresholds = listOf(),
+        durationAtAttenuationWeights = listOf(1.0f, 0.5f, 0.0f),
+        exposureRiskDuration = 15,
+        participatingCountries = listOf()
+    )
+
+    fun diagnosisKey() = DiagnosisKey(
+            keyData = "xAKM/2Mlz2RvfO/wKFAzpg==",
+            transmissionRiskLevel = 5,
+            rollingPeriod = 144,
+            rollingStartIntervalNumber = 2650847
     )
 }

--- a/owasp_suppressions.xml
+++ b/owasp_suppressions.xml
@@ -318,4 +318,32 @@
         <sha1>88a941faf9819d371e3174b5ed56a3f3f7d73269</sha1>
         <cve>CVE-2020-26939</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: jetified-kotlin-stdlib-1.4.10.jar
+   ]]></notes>
+        <sha1>ea29e063d2bbe695be13e9d044dcfb0c7add398e</sha1>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: jetified-kotlin-stdlib-common-1.4.10.jar
+   ]]></notes>
+        <sha1>6229be3465805c99db1142ad75e6c6ddeac0b04c</sha1>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: jetified-kotlin-stdlib-jdk7-1.4.10.jar
+   ]]></notes>
+        <sha1>30e46450b0bb3dbf43898d2f461be4a942784780</sha1>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: jetified-kotlin-stdlib-jdk8-1.4.10.jar
+   ]]></notes>
+        <sha1>998caa30623f73223194a8b657abd2baec4880ea</sha1>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
* Add new fields to backend API for received configuration and sent diagnosis keys
* This uses hardcoded temporary values for consent to share and visited countries to allow for integration testing