### PR TITLE
Fix country code validation to occur when data is received and stored

### DIFF
--- a/app/src/main/java/fi/thl/koronahaavi/diagnosis/ShareTravelChoiceData.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/diagnosis/ShareTravelChoiceData.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.map
 import fi.thl.koronahaavi.common.ChoiceData
 import fi.thl.koronahaavi.common.combineWith
 import fi.thl.koronahaavi.data.SettingsRepository
-import java.util.*
 
 /**
  * View model data elements for diagnosis data share to EU and travel
@@ -39,10 +38,7 @@ class ShareTravelChoiceData(settingsRepository: SettingsRepository) {
         use == true && (share == true || shareSelected == false)
     }
 
-    private val allCountries = settingsRepository.getExposureConfiguration()?.participatingCountries?.filter {
-        // Validate codes as additional security measure
-        Locale.getISOCountries().contains(it) && it != "FI"
-    }
+    private val allCountries = settingsRepository.getExposureConfiguration()?.participatingCountries
 
     private val selectedCountries = MutableLiveData<Set<String>>(setOf())
 

--- a/app/src/test/java/fi/thl/koronahaavi/diagnosis/ShareTravelChoiceDataTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/diagnosis/ShareTravelChoiceDataTest.kt
@@ -82,22 +82,6 @@ class ShareTravelChoiceDataTest {
     }
 
     @Test
-    fun participatingCountriesValidated() {
-        every { settingsRepository.getExposureConfiguration() } returns TestData.exposureConfiguration().copy(
-            participatingCountries = listOf("DE", "IE", "", "X", "test", "FI", " ", "3", "dk", "IT")
-        )
-
-        data = ShareTravelChoiceData(settingsRepository)
-
-        data.countries.test().assertValue {
-            it.size == 3 &&
-            it.any { c -> c.code == "IT" } &&
-            it.any { c -> c.code == "DE" } &&
-            it.any { c -> c.code == "IE" }
-        }
-    }
-
-    @Test
     fun summaryShowCountries() {
         val observer = data.summaryShowCountries.test()
         observer.assertNoValue()

--- a/app/src/test/java/fi/thl/koronahaavi/service/DiagnosisKeyServiceTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/service/DiagnosisKeyServiceTest.kt
@@ -156,6 +156,25 @@ class DiagnosisKeyServiceTest {
         }
     }
 
+    @Test
+    fun countryCodesFiltered() {
+        coEvery { backendService.getConfiguration() } returns TestData.exposureConfiguration().copy(
+            participatingCountries = listOf("DE", "IE", "", "X", "test", "FI", " ", "&&", "3", "dk", "IT")
+        )
+
+        val expectedCountries = listOf("DE", "IE", "IT")
+
+        runBlocking {
+            val result = diagnosisKeyService.downloadDiagnosisKeyFiles()
+
+            assertEquals(expectedCountries, result.exposureConfig.participatingCountries)
+
+            val savedConfig = slot<ExposureConfigurationData>()
+            verify { settingsRepository.updateExposureConfiguration(capture(savedConfig)) }
+            assertEquals(expectedCountries, savedConfig.captured.participatingCountries)
+        }
+    }
+
     private fun fakeKeyList() = listOf(fakeExposureKey(), fakeExposureKey())
 
     private fun fakeExposureKey() = TemporaryExposureKey.TemporaryExposureKeyBuilder()


### PR DESCRIPTION
Move country code validation from view model to diagnosis service, so it is done immediately when data is received from backend and prior to storing a local copy of config data