### PR TITLE
Diagnosis key batch file cleanup before download

### DIFF
--- a/app/src/androidTest/java/fi/thl/koronahaavi/service/SystemOperationsTest.kt
+++ b/app/src/androidTest/java/fi/thl/koronahaavi/service/SystemOperationsTest.kt
@@ -1,0 +1,37 @@
+package fi.thl.koronahaavi.service
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class SystemOperationsTest {
+    private lateinit var systemOperations: SystemOperations
+
+    @Before
+    fun init() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        systemOperations = SystemOperations(context)
+
+        context.filesDir.listFiles()?.forEach { it.delete() }
+    }
+
+    @Test
+    fun listFiles() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        File(context.filesDir, "test1.tmp").createNewFile()
+        File(context.filesDir, "test2.tmp").createNewFile()
+        File(context.filesDir, "test3tmp").createNewFile()
+        File(context.filesDir, "test4.TMP").createNewFile()
+        File(context.filesDir, "test5.tmp.txt").createNewFile()
+
+        val files = systemOperations.listFilesInPersistedStorage(".tmp")
+        assertEquals(true, files?.all { it.name == "test1.tmp" || it.name == "test2.tmp" })
+    }
+}

--- a/app/src/main/java/fi/thl/koronahaavi/service/SystemOperations.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/SystemOperations.kt
@@ -23,6 +23,11 @@ class SystemOperations @Inject constructor (
             createNewFile()
         }
 
+    fun listFilesInPersistedStorage(endingWith: String): Array<File>? =
+        context.filesDir.listFiles { _, name ->
+            name.endsWith(endingWith)
+        }
+
     fun fileExistsInPersistedStorage(filename: String): Boolean =
         File(context.filesDir, filename).exists()
 


### PR DESCRIPTION
Before each download, check if any previously downloaded diagnosis key batch files have been left over, possibly due to failed delete, or problems with provideDiagnosisKeys method.

This is only a safeguard since normally all downloaded files are deleted after calling provideDiagnosisKeys.