### PR TITLE
Android 11 package query permissions

### DIFF
--- a/app/src/liveHuawei/AndroidManifest.xml
+++ b/app/src/liveHuawei/AndroidManifest.xml
@@ -18,4 +18,10 @@
 
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="appmarket" />
+        </intent>
+    </queries>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,4 +76,16 @@
             android:exported="false" />
 
     </application>
+
+    <!-- Android 11 requires these query definitions to call intent.resolveActivity -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.DIAL" />
+            <data android:scheme="tel" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
Targeting SDK 30 requires definitions in app manifest for any intent signatures the app will attempt to resolve at runtime
https://developer.android.com/about/versions/11/privacy/package-visibility