### PR TITLE
Fix key mapping configuration for Huawei

### DIFF
--- a/app/src/liveHuawei/java/fi/thl/koronahaavi/service/HuaweiContactShieldService.kt
+++ b/app/src/liveHuawei/java/fi/thl/koronahaavi/service/HuaweiContactShieldService.kt
@@ -131,7 +131,9 @@ class HuaweiContactShieldService(
         }
     }
 
-    override suspend fun provideDiagnosisKeyFiles(files: List<File>): ResolvableResult<Unit> = resultFromRunning {
+    override suspend fun provideDiagnosisKeyFiles(config: ExposureConfigurationData, files: List<File>): ResolvableResult<Unit> = resultFromRunning {
+        // key mapping configuration must be applied before providing key batch files
+        updateKeyDataMapping(config)
 
         val intent = PendingIntent.getService(
                 context,

--- a/app/src/main/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorker.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorker.kt
@@ -82,7 +82,7 @@ class DiagnosisKeyUpdateWorker @AssistedInject constructor(
         Timber.i("Processing ${downloadResult.files.size} key files")
 
         val processResult = when (
-            val result = exposureNotificationService.provideDiagnosisKeyFiles(downloadResult.files)
+            val result = exposureNotificationService.provideDiagnosisKeyFiles(downloadResult.exposureConfig, downloadResult.files)
             ) {
 
             is ResolvableResult.Success -> {

--- a/app/src/main/java/fi/thl/koronahaavi/service/ExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/ExposureNotificationService.kt
@@ -20,7 +20,7 @@ interface ExposureNotificationService {
 
     suspend fun getDailyExposures(config: ExposureConfigurationData): List<DailyExposure>
     suspend fun getExposureWindows(): List<ExposureWindow>
-    suspend fun provideDiagnosisKeyFiles(files: List<File>): ResolvableResult<Unit>
+    suspend fun provideDiagnosisKeyFiles(config: ExposureConfigurationData, files: List<File>): ResolvableResult<Unit>
 
     suspend fun getTemporaryExposureKeys(): ResolvableResult<List<TemporaryExposureKey>>
     fun deviceSupportsLocationlessScanning(): Boolean

--- a/app/src/main/java/fi/thl/koronahaavi/service/FakeExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/FakeExposureNotificationService.kt
@@ -72,7 +72,7 @@ class FakeExposureNotificationService(
 
     override suspend fun getExposureWindows(): List<ExposureWindow> = listOf()
 
-    override suspend fun provideDiagnosisKeyFiles(files: List<File>): ResolvableResult<Unit> {
+    override suspend fun provideDiagnosisKeyFiles(config: ExposureConfigurationData, files: List<File>): ResolvableResult<Unit> {
         Timber.d("Got %d files", files.size)
 
         // actual system would save and process the files, but here we only send

--- a/app/src/main/java/fi/thl/koronahaavi/service/GoogleExposureNotificationService.kt
+++ b/app/src/main/java/fi/thl/koronahaavi/service/GoogleExposureNotificationService.kt
@@ -109,7 +109,7 @@ class GoogleExposureNotificationService(
         }
     }
 
-    override suspend fun provideDiagnosisKeyFiles(files: List<File>): ResolvableResult<Unit> {
+    override suspend fun provideDiagnosisKeyFiles(config: ExposureConfigurationData, files: List<File>): ResolvableResult<Unit> {
         Timber.d("Providing %d key files", files.size)
 
         return resultFromRunning {

--- a/app/src/test/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorkerTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/service/DiagnosisKeyUpdateWorkerTest.kt
@@ -97,7 +97,7 @@ class DiagnosisKeyUpdateWorkerTest {
             val result = worker.startWork().get()
 
             assertEquals(Result.success(), result)
-            coVerify(exactly = 0) { exposureNotificationService.provideDiagnosisKeyFiles(any()) }
+            coVerify(exactly = 0) { exposureNotificationService.provideDiagnosisKeyFiles(any(), any()) }
         }
     }
 
@@ -106,7 +106,7 @@ class DiagnosisKeyUpdateWorkerTest {
         coEvery { diagnosisKeyService.downloadDiagnosisKeyFiles() } returns
                 downloadResultWithFiles(listOf(File("")))
 
-        coEvery { exposureNotificationService.provideDiagnosisKeyFiles(any()) } returns
+        coEvery { exposureNotificationService.provideDiagnosisKeyFiles(any(), any()) } returns
                 ExposureNotificationService.ResolvableResult.Failed(1, 1, "error")
 
         runBlocking {
@@ -120,7 +120,7 @@ class DiagnosisKeyUpdateWorkerTest {
         coEvery { diagnosisKeyService.downloadDiagnosisKeyFiles() } returns
                 downloadResultWithFiles(listOf(File("")))
 
-        coEvery { exposureNotificationService.provideDiagnosisKeyFiles(any()) } returns
+        coEvery { exposureNotificationService.provideDiagnosisKeyFiles(any(), any()) } returns
                 ExposureNotificationService.ResolvableResult.Success(Unit)
 
         runBlocking {
@@ -135,7 +135,7 @@ class DiagnosisKeyUpdateWorkerTest {
         coEvery { diagnosisKeyService.downloadDiagnosisKeyFiles() } returns
                 downloadResultWithFiles(listOf(testFile))
 
-        coEvery { exposureNotificationService.provideDiagnosisKeyFiles(any()) } returns
+        coEvery { exposureNotificationService.provideDiagnosisKeyFiles(any(), any()) } returns
                 ExposureNotificationService.ResolvableResult.Success(Unit)
 
         runBlocking {

--- a/app/src/test/java/fi/thl/koronahaavi/service/GoogleExposureNotificationServiceTest.kt
+++ b/app/src/test/java/fi/thl/koronahaavi/service/GoogleExposureNotificationServiceTest.kt
@@ -130,7 +130,7 @@ class GoogleExposureNotificationServiceTest {
         )
 
         runBlocking {
-            val result = service.provideDiagnosisKeyFiles(listOf())
+            val result = service.provideDiagnosisKeyFiles(TestData.exposureConfiguration(), listOf())
             assertTrue(result is ExposureNotificationService.ResolvableResult.ApiNotSupported)
         }
     }
@@ -140,7 +140,7 @@ class GoogleExposureNotificationServiceTest {
         every { client.version } returns Tasks.forResult(15000000L)
 
         runBlocking {
-            val result = service.provideDiagnosisKeyFiles(listOf())
+            val result = service.provideDiagnosisKeyFiles(TestData.exposureConfiguration(), listOf())
             assertTrue(result is ExposureNotificationService.ResolvableResult.Failed)
         }
     }
@@ -150,7 +150,7 @@ class GoogleExposureNotificationServiceTest {
         every { client.version } returns Tasks.forResult(16000000L)
 
         runBlocking {
-            val result = service.provideDiagnosisKeyFiles(listOf())
+            val result = service.provideDiagnosisKeyFiles(TestData.exposureConfiguration(), listOf())
             assertTrue(result is ExposureNotificationService.ResolvableResult.Success)
         }
     }


### PR DESCRIPTION
Huawei Contact Shield requires that key mapping configuration for daily exposure summary calculation is applied before providing key batch files to the API.

This PR modifies Huawei implementation to do that, but does not change the Google implementation.